### PR TITLE
Replace deprecated Boost filesystem calls

### DIFF
--- a/src/Catalogue.cpp
+++ b/src/Catalogue.cpp
@@ -148,7 +148,7 @@ void Catalogue::initFrom(fs::path path) {
 			}
 		}
 		catch (const std::exception &ex) {
-			std::cerr << "directory_iterator died on '" << i->path().leaf() << "' with " << ex.what() << std::endl;
+                       std::cerr << "directory_iterator died on '" << i->path().filename() << "' with " << ex.what() << std::endl;
 		}
 	}	
 }

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -107,7 +107,7 @@ void Engine::loadGameData() {
 		if (fs::exists(palpath) && !fs::is_directory(palpath)) {
 			palette = new unsigned char[768];
 			
-			std::ifstream f(palpath.native_directory_string().c_str(), std::ios::binary);
+                       std::ifstream f(palpath.string().c_str(), std::ios::binary);
 			f >> std::noskipws;
 			f.read((char *)palette, 768);
 			
@@ -624,7 +624,7 @@ bool Engine::parseCommandLine(int argc, char *argv[]) {
 
 	// add all the data directories to the list
 	for (std::vector<std::string>::iterator i = data_vec.begin(); i != data_vec.end(); i++) {
-		fs::path datadir(*i, fs::native);
+               fs::path datadir(*i);
 		if (!fs::exists(datadir)) {
 			throw creaturesException("data path '" + *i + "' doesn't exist");
 		}
@@ -746,11 +746,11 @@ bool Engine::initialSetup() {
 		// inform the user of the port used, and store it in the relevant file
 		std::cout << "Listening for connections on port " << listenport << "." << std::endl;
 #ifndef _WIN32
-		fs::path p = fs::path(homeDirectory().native_directory_string() + "/.creaturesengine", fs::native);
+                fs::path p = fs::path(homeDirectory().string() + "/.creaturesengine");
 		if (!fs::exists(p))
 			fs::create_directory(p);
 		if (fs::is_directory(p)) {
-			std::ofstream f((p.native_directory_string() + "/port").c_str(), std::ios::trunc);
+                        std::ofstream f((p.string() + "/port").c_str(), std::ios::trunc);
 			f << boost::str(boost::format("%d") % listenport);
 		}
 #endif
@@ -776,7 +776,7 @@ bool Engine::initialSetup() {
 			throw creaturesException("multiple bootstrap files provided in C1/C2 mode");
 		
 		for (std::vector< std::string >::iterator bsi = cmdline_bootstrap.begin(); bsi != cmdline_bootstrap.end(); bsi++) {
-			fs::path scriptdir(*bsi, fs::native);
+                        fs::path scriptdir(*bsi);
 			if (engine.version > 2 || fs::extension(scriptdir) == ".cos") {
 				// pass it to the world to execute (it handles both files and directories)
 
@@ -792,7 +792,7 @@ bool Engine::initialSetup() {
 					throw creaturesException("non-existant bootstrap file provided in C1/C2 mode");
 				// TODO: the default SFCFile loading code is in World, maybe this should be too..
 				SFCFile sfc;
-				std::ifstream f(scriptdir.native_directory_string().c_str(), std::ios::binary);
+                                std::ifstream f(scriptdir.string().c_str(), std::ios::binary);
 				f >> std::noskipws;
 				sfc.read(&f);
 				sfc.copyToWorld();
@@ -832,18 +832,18 @@ fs::path Engine::homeDirectory() {
 #ifndef _WIN32
 	char *envhome = getenv("HOME");
 	if (envhome)
-		p = fs::path(envhome, fs::native);
+               p = fs::path(envhome);
 	if ((!envhome) || (!fs::is_directory(p)))
-		p = fs::path(getpwuid(getuid())->pw_dir, fs::native);
+               p = fs::path(getpwuid(getuid())->pw_dir);
 	if (!fs::is_directory(p)) {
 		std::cerr << "Can't work out what your home directory is, giving up and using /tmp for now." << std::endl;
-		p = fs::path("/tmp", fs::native); // sigh
+               p = fs::path("/tmp"); // sigh
 	}
 #else
 	TCHAR szPath[_MAX_PATH];
 	SHGetSpecialFolderPath(NULL, szPath, CSIDL_PERSONAL, TRUE);
 
-	p = fs::path(szPath, fs::native);
+       p = fs::path(szPath);
 	if (!fs::exists(p) || !fs::is_directory(p))
 		throw creaturesException("Windows reported that your My Documents folder is at '" + std::string(szPath) + "' but there's no directory there!");
 #endif
@@ -863,18 +863,18 @@ fs::path Engine::storageDirectory() {
 #endif
 	
 	// main storage dir
-	fs::path p = fs::path(homeDirectory().native_directory_string() + dirname, fs::native);
+       fs::path p = fs::path(homeDirectory().string() + dirname);
 	if (!fs::exists(p))
 		fs::create_directory(p);
 	else if (!fs::is_directory(p))
-		throw creaturesException("Your openc2e data directory " + p.native_directory_string() + " is a file, not a directory. That's bad.");
+               throw creaturesException("Your openc2e data directory " + p.string() + " is a file, not a directory. That's bad.");
 	
 	// game-specific storage dir
-	p = fs::path(p.native_directory_string() + std::string("/" + gamename), fs::native);
+       p = fs::path(p.string() + std::string("/" + gamename));
 	if (!fs::exists(p))
 		fs::create_directory(p);
 	else if (!fs::is_directory(p))
-		throw creaturesException("Your openc2e game data directory " + p.native_directory_string() + " is a file, not a directory. That's bad.");
+               throw creaturesException("Your openc2e game data directory " + p.string() + " is a file, not a directory. That's bad.");
 	
 	return p;
 }

--- a/src/PathResolver.cpp
+++ b/src/PathResolver.cpp
@@ -48,14 +48,14 @@ static string toLowerCase(string in) {
 }
 
 static path lcpath(path &orig) {
-	return path(toLowerCase(orig.string()), native);
+       return path(toLowerCase(orig.string()));
 }
 
 static path lcleaf(path &orig) {
-	path br, leaf;
-	br = orig.branch_path();
-	leaf = path(toLowerCase(orig.leaf()), native);
-	return br / leaf;
+       path br, leaf;
+       br = orig.parent_path();
+       leaf = path(toLowerCase(orig.filename()));
+       return br / leaf;
 }
 
 bool resolveFile(path &p) {
@@ -68,7 +68,7 @@ bool resolveFile(path &p) {
 		if (!resolveFile(s))
 			return false;
 	}
-	p = path(s, native);
+       p = path(s);
 	return true;
 #else
 	return exists(p);
@@ -76,13 +76,13 @@ bool resolveFile(path &p) {
 }
 
 bool resolveFile_(string &srcPath) {
-	path orig(srcPath, native);
+       path orig(srcPath);
 	if (exists(orig))
 		return true;
 	
-	orig.normalize();
-	path dir = orig.branch_path();
-	path leaf = path(orig.leaf(), native);
+       orig = orig.lexically_normal();
+       path dir = orig.parent_path();
+       path leaf = path(orig.filename());
 
 	if (!checkDirCache(dir))
 		return false;
@@ -180,8 +180,8 @@ std::vector<std::string> findByWildcard(std::string dir, std::string wild) {
 
 	wild = toLowerCase(wild);
 
-	path dirp(dir, native);
-	dirp.normalize();
+       path dirp(dir);
+       dirp = dirp.lexically_normal();
 	if (!resolveFile(dirp))
 		return std::vector<std::string>();
 	dir = dirp.string();

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -515,7 +515,7 @@ void World::executeInitScript(fs::path p) {
 	assert(fs::exists(p));
 	assert(!fs::is_directory(p));
 
-	std::string x = p.native_file_string();
+       std::string x = p.string();
 	std::ifstream s(x.c_str());
 	assert(s.is_open());
 	//std::cout << "executing script " << x << "...\n";
@@ -527,9 +527,9 @@ void World::executeInitScript(fs::path p) {
 		script.installScripts();
 		vm.runEntirely(script.installer);
 	} catch (creaturesException &e) {
-		std::cerr << "exec of \"" << p.leaf() << "\" failed due to exception " << e.prettyPrint() << std::endl;
+               std::cerr << "exec of \"" << p.filename() << "\" failed due to exception " << e.prettyPrint() << std::endl;
 	} catch (std::exception &e) {
-		std::cerr << "exec of \"" << p.leaf() << "\" failed due to exception " << e.what() << std::endl;
+               std::cerr << "exec of \"" << p.filename() << "\" failed due to exception " << e.what() << std::endl;
 	}
 	std::cout.flush(); std::cerr.flush();
 }
@@ -564,7 +564,7 @@ void World::executeBootstrap(bool switcher) {
 		fs::path edenpath(data_directories[0] / "/Eden.sfc");
 		if (fs::exists(edenpath) && !fs::is_directory(edenpath)) {
 			SFCFile sfc;
-			std::ifstream f(edenpath.native_directory_string().c_str(), std::ios::binary);
+                       std::ifstream f(edenpath.string().c_str(), std::ios::binary);
 			f >> std::noskipws;
 			sfc.read(&f);
 			sfc.copyToWorld();
@@ -585,7 +585,7 @@ void World::executeBootstrap(bool switcher) {
 			// iterate through each bootstrap directory
 			for (fs::directory_iterator d(b); d != fsend; ++d) {
 				if (fs::exists(*d) && fs::is_directory(*d)) {
-					std::string s = d->path().leaf();
+                                       std::string s = d->path().filename();
 					// TODO: cvillage has switcher code in 'Startup', so i included it here too
 					if (s == "000 Switcher" || s == "Startup") {
 						if (!switcher) continue;
@@ -620,7 +620,7 @@ std::string World::findFile(std::string name) {
 	// Go backwards, so we find files in more 'modern' directories first..
 	for (int i = data_directories.size() - 1; i != -1; i--) {
 		fs::path p = data_directories[i];
-		std::string r = (p / fs::path(name, fs::native)).native_directory_string();
+               std::string r = (p / fs::path(name)).string();
 		if (resolveFile(r))
 			return r;
 	}
@@ -634,7 +634,7 @@ std::vector<std::string> World::findFiles(std::string dir, std::string wild) {
 	// Go backwards, so we find files in more 'modern' directories first..
 	for (int i = data_directories.size() - 1; i != -1; i--) {
 		fs::path p = data_directories[i];
-		std::string r = (p / fs::path(dir, fs::native)).native_directory_string();
+               std::string r = (p / fs::path(dir)).string();
 		std::vector<std::string> results = findByWildcard(r, wild);
 		possibles.insert(possibles.end(), results.begin(), results.end()); // merge results
 	}
@@ -643,7 +643,7 @@ std::vector<std::string> World::findFiles(std::string dir, std::string wild) {
 }
 
 std::string World::getUserDataDir() {
-	return (data_directories.end() - 1)->native_directory_string();
+       return (data_directories.end() - 1)->string();
 }
 
 void World::selectCreature(boost::shared_ptr<Agent> a) {

--- a/src/backends/qtgui/AgentInjector.cpp
+++ b/src/backends/qtgui/AgentInjector.cpp
@@ -97,7 +97,7 @@ void AgentInjector::readAgents() {
 			std::transform(cobext.begin(), cobext.end(), cobext.begin(), (int(*)(int))tolower); // downcase
 			if (cobext != ".cob") continue;
 			
-			std::string cob = itr->path().native_file_string();
+                       std::string cob = itr->path().string();
 			
 			if (engine.version == 1) {
 				std::ifstream cobstream(cob.c_str(), std::ios::binary);
@@ -166,8 +166,8 @@ void AgentInjector::onInject() {
 			std::string directory = world.praymanager.getResourceDir(praytype);
 			caos_assert(!directory.empty());
 		
-			fs::path possiblefile = fs::path(directory, fs::native) / fs::path(name, fs::native);
-			if (!world.findFile(possiblefile.native_directory_string()).empty()) continue; // TODO: update file if necessary?
+                       fs::path possiblefile = fs::path(directory) / fs::path(name);
+                       if (!world.findFile(possiblefile.string()).empty()) continue; // TODO: update file if necessary?
 
 			std::vector<cobBlock *>::iterator j;
 
@@ -179,15 +179,15 @@ void AgentInjector::onInject() {
 				cobFileBlock *a = new cobFileBlock(*j);
 				if (a->filetype == type && a->filename == name) {
 					// Found dependency!
-					fs::path dir = fs::path(world.getUserDataDir(), fs::native) / fs::path(directory, fs::native);
+                                       fs::path dir = fs::path(world.getUserDataDir()) / fs::path(directory);
 					if (!fs::exists(dir))
 						fs::create_directory(dir);
 					assert(fs::exists(dir) && fs::is_directory(dir)); // TODO: error handling
 
-					fs::path outputfile = dir / fs::path(name, fs::native);
+                                       fs::path outputfile = dir / fs::path(name);
 					assert(!fs::exists(outputfile));
 
-					std::ofstream output(outputfile.native_directory_string().c_str(), std::ios::binary);
+                                       std::ofstream output(outputfile.string().c_str(), std::ios::binary);
 					output.write((char *)a->getFileContents(), a->filesize);
 
 					a->getParent()->free();

--- a/src/caos/caosVM_core.cpp
+++ b/src/caos/caosVM_core.cpp
@@ -346,7 +346,7 @@ void caosVM::v_OC2E_DDIR() {
 
 	for (std::vector<boost::filesystem::path>::iterator i = world.data_directories.begin(); i != world.data_directories.end(); i++) {
 		boost::filesystem::path &p = *i;
-		d = d + boost::filesystem::system_complete(p).native_file_string() + "\n";
+               d = d + boost::filesystem::absolute(p).string() + "\n";
 	}
 	
 	result.setString(d);

--- a/src/caos/caosVM_files.cpp
+++ b/src/caos/caosVM_files.cpp
@@ -59,7 +59,7 @@ std::string calculateJournalFilename(int directory, std::string filename, bool w
 		default: throw caosException("unknown Journal directory");
 	}
 	
-	fs::path dir = fs::path(fullfilename, fs::native);
+       fs::path dir = fs::path(fullfilename);
 	if (!fs::exists(dir))
 		fs::create_directory(dir);
 	caos_assert(fs::exists(dir) && fs::is_directory(dir));

--- a/src/caos/caosVM_resources.cpp
+++ b/src/caos/caosVM_resources.cpp
@@ -29,19 +29,19 @@ bool prayInstall(std::string name, unsigned int type, bool actually_install) {
 	std::string directory = world.praymanager.getResourceDir(type);
 	caos_assert(!directory.empty());
 
-	fs::path dir = fs::path(world.getUserDataDir(), fs::native) / fs::path(directory, fs::native);
+       fs::path dir = fs::path(world.getUserDataDir()) / fs::path(directory);
 	if (!fs::exists(dir))
 		fs::create_directory(dir);
 	caos_assert(fs::exists(dir) && fs::is_directory(dir));
 
-	fs::path outputfile = dir / fs::path(name, fs::native);
+       fs::path outputfile = dir / fs::path(name);
 	if (fs::exists(outputfile)) {
 		// TODO: update file if necessary? check it's not a directory :P
 		return true;
 	}
 
-	fs::path possiblefile = fs::path(directory, fs::native) / fs::path(name, fs::native);
-	if (!world.findFile(possiblefile.native_directory_string()).empty()) {
+       fs::path possiblefile = fs::path(directory) / fs::path(name);
+       if (!world.findFile(possiblefile.string()).empty()) {
 		// TODO: we need to return 'okay' if the file exists anywhere, but someone needs to work out update behaviour (see other comment above, also)
 		return true;
 	}
@@ -65,7 +65,7 @@ bool prayInstall(std::string name, unsigned int type, bool actually_install) {
 	}
 
 	p->load();
-	std::ofstream output(outputfile.native_directory_string().c_str(), std::ios::binary);
+       std::ofstream output(outputfile.string().c_str(), std::ios::binary);
 	output.write((char *)p->getBuffer(), p->getSize());
 	// p->unload();
 	

--- a/src/cobFile.cpp
+++ b/src/cobFile.cpp
@@ -23,16 +23,16 @@
 
 cobFile::cobFile(fs::path filepath) {
 	path = filepath;
-	file.open(path.native_directory_string().c_str(), std::ios::binary);
+       file.open(path.string().c_str(), std::ios::binary);
 
 	if (!file.is_open())
-		throw creaturesException(std::string("couldn't open COB file \"") + path.native_directory_string() + "\"");
+               throw creaturesException(std::string("couldn't open COB file \"") + path.string() + "\"");
 
 	// TODO: c1 cob support
 	char majic[4];
 	file.read(majic, 4);
 	if (strncmp(majic, "cob2", 4) != 0)
-		throw creaturesException(std::string("bad magic of C2 COB file \"") + path.native_directory_string() + "\"");
+               throw creaturesException(std::string("bad magic of C2 COB file \"") + path.string() + "\"");
 	
 	while (!file.eof()) {
 		// TODO: catch exceptions, and free all blocks before passing it up the stack

--- a/src/imageManager.cpp
+++ b/src/imageManager.cpp
@@ -45,14 +45,14 @@ bool tryOpen(mmapifstream *in, shared_ptr<creaturesImage> &img, std::string fnam
 	std::string cachename;
 	if (fname.size() < 5) return false; // not enough chars for an extension and filename..
 
-	realfile = path(world.findFile(fname), native);
+       realfile = path(world.findFile(fname));
 	// if it doesn't exist, too bad, give up.
 	if (!exists(realfile)) return false;
 	
-	std::string basename = realfile.leaf(); basename.erase(basename.end() - 4, basename.end()); 
+       std::string basename = realfile.filename(); basename.erase(basename.end() - 4, basename.end());
 	
 	// work out where the cached file should be
-	cachename = engine.storageDirectory().native_directory_string() + "/" + fname;
+       cachename = engine.storageDirectory().string() + "/" + fname;
 	if (ft == c16) { // TODO: we should really stop the caller from appending .s16/.c16
 		cachename.erase(cachename.end() - 4, cachename.end());
 		cachename.append(".s16");
@@ -62,39 +62,39 @@ bool tryOpen(mmapifstream *in, shared_ptr<creaturesImage> &img, std::string fnam
 	if (ft != spr)
 		cachename = cachename + ".big";
 #endif
-	cachefile = path(cachename, native);
+       cachefile = path(cachename);
 
 	if (resolveFile(cachefile)) {
 		// TODO: check for up-to-date-ness
 		in->clear();
-		in->mmapopen(cachefile.native_file_string());
+               in->mmapopen(cachefile.string());
 		if (ft == c16) ft = s16;
 		goto done;
 	}
-	//std::cout << "couldn't find cached version: " << cachefile.native_file_string() << std::endl;
+        //std::cout << "couldn't find cached version: " << cachefile.string() << std::endl;
 
-	in->clear();
-	in->mmapopen(realfile.native_file_string());
+       in->clear();
+       in->mmapopen(realfile.string());
 #if OC2E_BIG_ENDIAN
 	if (in->is_open() && (ft != spr)) {
-		path p = cachefile.branch_path();
+               path p = cachefile.parent_path();
 		if (!exists(p))
 			create_directory(p);
 		if (!is_directory(p))
-			throw creaturesException("imageManager couldn't create cache directory '" + p.native_directory_string() + "'");
+                       throw creaturesException("imageManager couldn't create cache directory '" + p.string() + "'");
 
 		fileSwapper f;
 		switch (ft) {
 			case blk:
-				f.convertblk(realfile.native_file_string(), cachefile.native_file_string());
+                               f.convertblk(realfile.string(), cachefile.string());
 				break;
 			case s16:
-				f.converts16(realfile.native_file_string(), cachefile.native_file_string());
+                               f.converts16(realfile.string(), cachefile.string());
 				break;
 			case c16:
 				//cachefile = change_extension(cachefile, "");
 				//cachefile = change_extension(cachefile, ".s16.big");
-				f.convertc16(realfile.native_file_string(), cachefile.native_file_string());
+                               f.convertc16(realfile.string(), cachefile.string());
 				ft = s16;
 				break;
 			default:
@@ -102,7 +102,7 @@ bool tryOpen(mmapifstream *in, shared_ptr<creaturesImage> &img, std::string fnam
 		}
 		in->close(); // TODO: close the mmap too! how?
 		if (!exists(cachefile)) return false; // TODO: exception?
-		in->mmapopen(cachefile.native_file_string());
+               in->mmapopen(cachefile.string());
 	}
 #endif
 done:

--- a/src/peFile.cpp
+++ b/src/peFile.cpp
@@ -48,16 +48,16 @@ std::string nameForType(uint32 t) {
 
 peFile::peFile(fs::path filepath) {
 	path = filepath;
-	file.open(path.native_directory_string().c_str(), std::ios::binary);
+       file.open(path.string().c_str(), std::ios::binary);
 
 	if (!file.is_open())
-		throw creaturesException(std::string("couldn't open PE file \"") + path.native_directory_string() + "\"");
+               throw creaturesException(std::string("couldn't open PE file \"") + path.string() + "\"");
 
 	// check the signature of the file
 	char majic[2];
 	file.read(majic, 2);
 	if (strncmp(majic, "MZ", 2) != 0)
-		throw creaturesException(std::string("couldn't understand PE file \"") + path.native_directory_string() + "\" (not a PE file?)");
+               throw creaturesException(std::string("couldn't understand PE file \"") + path.string() + "\" (not a PE file?)");
 
 	// skip the rest of the DOS header
 	file.seekg(58, std::ios::cur);
@@ -65,14 +65,14 @@ peFile::peFile(fs::path filepath) {
 	// read the location of the PE header
 	uint32 e_lfanew = read32(file);
 	if (e_lfanew == 0)
-		throw creaturesException(std::string("couldn't understand PE file \"") + path.native_directory_string() + "\" (DOS program?)");
+               throw creaturesException(std::string("couldn't understand PE file \"") + path.string() + "\" (DOS program?)");
 
 	// seek to the PE header and check the signature
 	file.seekg(e_lfanew, std::ios::beg);
 	char pemajic[4];
 	file.read(pemajic, 4);
 	if (memcmp(pemajic, "PE\0\0", 4) != 0)
-		throw creaturesException(std::string("couldn't understand PE file \"") + path.native_directory_string() + "\" (corrupt?)");
+               throw creaturesException(std::string("couldn't understand PE file \"") + path.string() + "\" (corrupt?)");
 
 	// read the necessary data from the PE file header
 	file.seekg(2, std::ios::cur);

--- a/src/pray.cpp
+++ b/src/pray.cpp
@@ -24,14 +24,14 @@
 
 prayFile::prayFile(fs::path filepath) {
 	path = filepath;
-	file.open(path.native_directory_string().c_str(), std::ios::binary);
+       file.open(path.string().c_str(), std::ios::binary);
 	if (!file.is_open())
-		throw creaturesException(std::string("couldn't open PRAY file \"") + path.native_directory_string() + "\"");
+               throw creaturesException(std::string("couldn't open PRAY file \"") + path.string() + "\"");
 	
 	char majic[4];
 	file.read(majic, 4);
 	if (strncmp(majic, "PRAY", 4) != 0)
-		throw creaturesException(std::string("bad magic of PRAY file \"") + path.native_directory_string() + "\"");
+               throw creaturesException(std::string("bad magic of PRAY file \"") + path.string() + "\"");
 
 	while (!file.eof()) {
 		// TODO: catch exceptions, and free all blocks before passing it up the stack

--- a/src/prayManager.cpp
+++ b/src/prayManager.cpp
@@ -74,7 +74,7 @@ void prayManager::update() {
 		assert(fs::exists(*i));
 		assert(fs::is_directory(*i));
 
-		fs::path praydir(*i / fs::path("/My Agents/", fs::native));
+               fs::path praydir(*i / fs::path("/My Agents/"));
 		
 		if (fs::exists(praydir) && fs::is_directory(praydir)) {
 			fs::directory_iterator fsend;
@@ -83,12 +83,12 @@ void prayManager::update() {
 				if (!x.empty()) x.erase(x.begin());
 				if (std::find(extensions.begin(), extensions.end(), x) != extensions.end()) {
 					// TODO: language checking!
-					//std::cout << "scanning PRAY file " << d->path().native_directory_string() << std::endl;
+                                       //std::cout << "scanning PRAY file " << d->path().string() << std::endl;
 					try {
 						prayFile *p = new prayFile(*d);
 						addFile(p);
 					} catch (creaturesException &e) {
-						std::cerr << "PRAY file \"" << d->path().native_directory_string() << "\" failed to load: " << e.what() << std::endl;
+                                               std::cerr << "PRAY file \"" << d->path().string() << "\" failed to load: " << e.what() << std::endl;
 					}
 				}
 			}

--- a/src/tools/praydumper.cpp
+++ b/src/tools/praydumper.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 
-	fs::path inputfile = fs::path(argv[0], fs::native);
+    fs::path inputfile = fs::path(argv[0]);
 	if (!fs::exists(inputfile)) {
 		cerr << "input file doesn't exist!" << endl;
 		return 1;


### PR DESCRIPTION
## Summary
- modernize Boost::filesystem calls across the project
- replace deprecated functions (branch_path, leaf, normalize, system_complete, etc.)
- drop use of `fs::native` and use standard `string()`

## Testing
- `cmake -DOPENC2E_USE_QT=FALSE .. && make -j$(nproc)` *(fails: `parsedocs.pl` missing perl dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840e076b1b0832ab1b4bd474a3ac23f