### PR TITLE
Use std::shared_ptr everywhere

### DIFF
--- a/src/Agent.cpp
+++ b/src/Agent.cpp
@@ -113,7 +113,7 @@ void Agent::finishInit() {
 	
 	// shared_from_this() can only be used if these is at least one extant
 	// shared_ptr which owns this
-	world.agents.push_front(boost::shared_ptr<Agent>(this));
+	world.agents.push_front(std::shared_ptr<Agent>(this));
 	agents_iter = world.agents.begin();
 
 	if (engine.version > 2 && findScript(10))
@@ -214,7 +214,7 @@ void Agent::delFloated(AgentRef a) {
 	floated.erase(i);
 }
 
-shared_ptr<script> Agent::findScript(unsigned short event) {
+std::shared_ptr<script> Agent::findScript(unsigned short event) {
 	return world.scriptorium.getScript(family, genus, species, event);
 }
 
@@ -291,7 +291,7 @@ bool Agent::fireScript(unsigned short event, Agent *from, caosVar one, caosVar t
 
 	bool ranscript = false;
 
-	shared_ptr<script> s = findScript(event);
+	std::shared_ptr<script> s = findScript(event);
 	if (s) {
 		bool madevm = false;
 		if (!vm) { madevm = true; vm = world.getVM(this); }
@@ -327,7 +327,7 @@ bool Agent::fireScript(unsigned short event, Agent *from, caosVar one, caosVar t
 			// drop script starts (see for instance C1 carrots, which change pose)
 			MetaRoom* m = world.map.metaRoomAt(x, y);
 			if (!m) break;
-			shared_ptr<Room> r = m->nextFloorFromPoint(x, y);
+			std::shared_ptr<Room> r = m->nextFloorFromPoint(x, y);
 			if (!r) break;
 			moveTo(x, r->bot.pointAtX(x).y - getHeight());
 			
@@ -414,7 +414,7 @@ static bool inrange_at(const MetaRoom *room, float x, float y, unsigned int widt
 	return true;
 }
 
-void Agent::updateAudio(boost::shared_ptr<AudioSource> s) {
+void Agent::updateAudio(std::shared_ptr<AudioSource> s) {
 	assert(s);
 	MetaRoom *room = world.map.metaRoomAt(x, y);
 	if (!room) {
@@ -528,7 +528,7 @@ bool Agent::validInRoomSystem(Point p, float w, float h, int testperm) {
 
 			float srcx = src.x, srcy = src.y;
 
-			shared_ptr<Room> ourRoom = m->roomAt(srcx, srcy);
+			std::shared_ptr<Room> ourRoom = m->roomAt(srcx, srcy);
 			if (!ourRoom) return false;
 
 			unsigned int dir; Line wall;
@@ -610,7 +610,7 @@ void Agent::physicsTick() {
 			// store values
 			float srcx = src.x, srcy = src.y;
 			
-			shared_ptr<Room> ourRoom = world.map.roomAt(srcx, srcy);
+			std::shared_ptr<Room> ourRoom = world.map.roomAt(srcx, srcy);
 			if (!ourRoom) {
 				ourRoom = world.map.roomAt(srcx, srcy);
 			}
@@ -747,12 +747,12 @@ void Agent::physicsTick() {
 	}
 }
 
-shared_ptr<Room> const Agent::bestRoomAt(unsigned int tryx, unsigned int tryy, unsigned int direction, MetaRoom *m, shared_ptr<Room> exclude) {
-	std::vector<shared_ptr<Room> > rooms = m->roomsAt(tryx, tryy);
+std::shared_ptr<Room> const Agent::bestRoomAt(unsigned int tryx, unsigned int tryy, unsigned int direction, MetaRoom *m, std::shared_ptr<Room> exclude) {
+	std::vector<std::shared_ptr<Room> > rooms = m->roomsAt(tryx, tryy);
 
-	shared_ptr<Room> r;
+	std::shared_ptr<Room> r;
 
-	if (rooms.size() == 0) return shared_ptr<Room>();
+	if (rooms.size() == 0) return std::shared_ptr<Room>();
 	if (rooms.size() == 1) r = rooms[0];
 	else if (rooms.size() > 1) {
 		unsigned int j;
@@ -773,7 +773,7 @@ shared_ptr<Room> const Agent::bestRoomAt(unsigned int tryx, unsigned int tryy, u
 		r = rooms[j];
 	}
 
-	if (r == exclude) return shared_ptr<Room>();
+	if (r == exclude) return std::shared_ptr<Room>();
 	else return r;
 }
 
@@ -788,9 +788,9 @@ void Agent::findCollisionInDirection(unsigned int i, class MetaRoom *m, Point sr
 	}
 
 	// TODO: caching rooms affects behaviour - work out if that's a problem
-	shared_ptr<Room> room = roomcache[i].lock();
+	std::shared_ptr<Room> room = roomcache[i].lock();
 	if (!room || !room->containsPoint(src.x, src.y)) {
-		room = bestRoomAt(src.x, src.y, i, m, shared_ptr<Room>());
+		room = bestRoomAt(src.x, src.y, i, m, std::shared_ptr<Room>());
 		roomcache[i] = room;
 	}
 
@@ -876,7 +876,7 @@ void Agent::findCollisionInDirection(unsigned int i, class MetaRoom *m, Point sr
 				else if (dx < 0 && src.x + p.x <= m->x()) src.x += m->width();
 			}
 
-			shared_ptr<Room> newroom = bestRoomAt(src.x + p.x, src.y + p.y, i, m, room);
+			std::shared_ptr<Room> newroom = bestRoomAt(src.x + p.x, src.y + p.y, i, m, room);
 
 			bool collision = false;
 
@@ -1022,7 +1022,7 @@ void Agent::tick() {
 	// CA updates
 	if (emitca_index != -1 && emitca_amount != 0.0f) {
 		assert(0 <= emitca_index && emitca_index <= 19);
-		shared_ptr<Room> r = world.map.roomAt(x, y);
+		std::shared_ptr<Room> r = world.map.roomAt(x, y);
 		if (r) {
 			r->catemp[emitca_index] += emitca_amount;
 			/*if (r->catemp[emitca_index] <= 0.0f) r->catemp[emitca_index] = 0.0f;
@@ -1300,8 +1300,8 @@ bool Agent::beDropped() {
 
 	if (!wasinvehicle) { // ie, we're not being dropped by a vehicle
 		// TODO: check for vehicles in a saner manner?
-		for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
-			boost::shared_ptr<Agent> a = (*i);
+		for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+			std::shared_ptr<Agent> a = (*i);
 			if (!a) continue;
 			Vehicle *v = dynamic_cast<Vehicle *>(a.get());
 			if (!v) continue;
@@ -1462,9 +1462,9 @@ void Agent::setVoice(std::string name) {
 		if (!path.size()) throw creaturesException(boost::str(boost::format("can't find %s.vce") % name));
 		std::ifstream f(path.c_str());
 		if (!f.is_open()) throw creaturesException(boost::str(boost::format("can't open %s.vce") % name));
-		voice = shared_ptr<VoiceData>(new VoiceData(f));
+		voice = std::shared_ptr<VoiceData>(new VoiceData(f));
 	} else {
-		voice = shared_ptr<VoiceData>(new VoiceData(name));
+		voice = std::shared_ptr<VoiceData>(new VoiceData(name));
 	}
 }
 

--- a/src/Agent.h
+++ b/src/Agent.h
@@ -22,7 +22,7 @@
 
 #include "AgentRef.h"
 #include <boost/enable_shared_from_this.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "caosVar.h"
 #include "CompoundPart.h"
 #include <list>
@@ -70,7 +70,7 @@ protected:
 	
 	int unused_cint;
 	
-	std::map<unsigned int, boost::shared_ptr<genomeFile> > genome_slots;
+	std::map<unsigned int, std::shared_ptr<genomeFile> > genome_slots;
 	
 	class caosVM *vm;
 
@@ -86,11 +86,11 @@ protected:
 	int lastcollidedirection;
 
 	std::multiset<Agent *, agentzorder>::iterator zorder_iter;
-	std::list<boost::shared_ptr<Agent> >::iterator agents_iter;
+	std::list<std::shared_ptr<Agent> >::iterator agents_iter;
 	std::list<caosVM *> vmstack; // for CALL etc
 	std::vector<AgentRef> floated;
 
-	void updateAudio(boost::shared_ptr<class AudioSource>);
+	void updateAudio(std::shared_ptr<class AudioSource>);
 	bool dying : 1;
 	
 	void vmTick();
@@ -109,17 +109,17 @@ protected:
 public:
 	std::map<unsigned int, std::pair<int, int> > carry_points, carried_points;
 
-	boost::shared_ptr<class VoiceData> voice;
+	std::shared_ptr<class VoiceData> voice;
 	std::vector<std::pair<std::string, unsigned int> > pending_voices;
 	void setVoice(std::string name);
 	void speak(std::string sentence);
 	void tickVoices();
 	
-	boost::shared_ptr<class AudioSource> sound;
+	std::shared_ptr<class AudioSource> sound;
 
 	// these are maps rather than vectors because ports can be destroyed
-	std::map<unsigned int, boost::shared_ptr<InputPort> > inports; // XXX: do these need to be shared_ptr?
-	std::map<unsigned int, boost::shared_ptr<OutputPort> > outports;
+	std::map<unsigned int, std::shared_ptr<InputPort> > inports; // XXX: do these need to be shared_ptr?
+	std::map<unsigned int, std::shared_ptr<OutputPort> > outports;
 
 	void join(unsigned int outid, AgentRef dest, unsigned int inid);
 
@@ -202,7 +202,7 @@ public:
 
 	bool falling : 1; // TODO: icky hack, possibly
 	bool moved_last_tick : 1; // TODO: icky hack
-	boost::weak_ptr<class Room> roomcache[5];
+	std::weak_ptr<class Room> roomcache[5];
 
 	caosVar range;
 
@@ -250,7 +250,7 @@ public:
 	unsigned int getHeight() { return part(0)->getHeight(); }
 	Point const boundingBoxPoint(unsigned int n);
 	Point const boundingBoxPoint(unsigned int n, Point p, float w, float h);
-	shared_ptr<class Room> const bestRoomAt(unsigned int x, unsigned int y, unsigned int direction, class MetaRoom *m, shared_ptr<Room> exclude);
+	std::shared_ptr<class Room> const bestRoomAt(unsigned int x, unsigned int y, unsigned int direction, class MetaRoom *m, std::shared_ptr<Room> exclude);
 	void findCollisionInDirection(unsigned int i, class MetaRoom *m, Point src, int &dx, int &dy, Point &deltapt, double &delta, bool &collided, bool followrooms);
 
 	bool validInRoomSystem();
@@ -263,7 +263,7 @@ public:
 	virtual void setZOrder(unsigned int plane); // should be overridden!
 	virtual unsigned int getZOrder() const;
 
-	class shared_ptr<script> findScript(unsigned short event);
+	class std::shared_ptr<script> findScript(unsigned short event);
 	
 	int getUNID() const;
 	std::string identify() const;
@@ -273,7 +273,7 @@ public:
 
 	void playAudio(std::string filename, bool controlled, bool loop);
 
-	boost::shared_ptr<genomeFile> getSlot(unsigned int s) { return genome_slots[s]; }
+	std::shared_ptr<genomeFile> getSlot(unsigned int s) { return genome_slots[s]; }
 };
 
 class LifeAssert {
@@ -285,12 +285,12 @@ class LifeAssert {
 			assert(p);
 			p->lifecount++;
 		}
-		LifeAssert(const boost::weak_ptr<Agent> &p_) {
+		LifeAssert(const std::weak_ptr<Agent> &p_) {
 			p = p_.lock().get();
 			assert(p);
 			p->lifecount++;
 		}
-		LifeAssert(const boost::shared_ptr<Agent> &p_) {
+		LifeAssert(const std::shared_ptr<Agent> &p_) {
 			p = p_.get();
 			assert(p);
 			p->lifecount++;

--- a/src/AgentHelpers.cpp
+++ b/src/AgentHelpers.cpp
@@ -22,7 +22,7 @@
 #include "MetaRoom.h"
 #include "Room.h"
 
-bool agentIsVisible(Agent *seeing, Agent *a, float ownerx, float ownery, MetaRoom *ownermeta, shared_ptr<Room> ownerroom) {
+bool agentIsVisible(Agent *seeing, Agent *a, float ownerx, float ownery, MetaRoom *ownermeta, std::shared_ptr<Room> ownerroom) {
 	assert(ownermeta && ownerroom);
 
 	if (seeing == a) return false;
@@ -32,7 +32,7 @@ bool agentIsVisible(Agent *seeing, Agent *a, float ownerx, float ownery, MetaRoo
 	float thisy = a->y + (a->getHeight() / 2.0f);
 	MetaRoom *m = world.map.metaRoomAt(thisx, thisy);
 	if (m != ownermeta) return false;
-	shared_ptr<Room> r = world.map.roomAt(thisx, thisy);
+	std::shared_ptr<Room> r = world.map.roomAt(thisx, thisy);
 	if (!r) return false;
 		
 	// compare squared distance with range
@@ -43,7 +43,7 @@ bool agentIsVisible(Agent *seeing, Agent *a, float ownerx, float ownery, MetaRoo
 	// do the actual visibiltiy check using a line between centers
 	Point src(ownerx, ownery), dest(thisx, thisy);
 	Line dummywall; unsigned int dummydir;
-	shared_ptr<Room> newroom = ownerroom;
+	std::shared_ptr<Room> newroom = ownerroom;
 	world.map.collideLineWithRoomSystem(src, dest, newroom, src, dummywall, dummydir, seeing->perm);
 	if (src != dest) return false;
 
@@ -54,24 +54,24 @@ bool agentIsVisible(Agent *seeing, Agent *dest) {
 	float ownerx = (seeing->x + (seeing->getWidth() / 2.0f));
 	float ownery = (seeing->y + (seeing->getHeight() / 2.0f));
 	MetaRoom *ownermeta = world.map.metaRoomAt(ownerx, ownery);
-	shared_ptr<Room> ownerroom = world.map.roomAt(ownerx, ownery);
+	std::shared_ptr<Room> ownerroom = world.map.roomAt(ownerx, ownery);
 	if (!ownermeta) return false; if (!ownerroom) return false;
 
 	return agentIsVisible(seeing, dest, ownerx, ownery, ownermeta, ownerroom);
 }
 
-std::vector<boost::shared_ptr<Agent> > getVisibleList(Agent *seeing, unsigned char family, unsigned char genus, unsigned short species) {
-	std::vector<boost::shared_ptr<Agent> > agents;
+std::vector<std::shared_ptr<Agent> > getVisibleList(Agent *seeing, unsigned char family, unsigned char genus, unsigned short species) {
+	std::vector<std::shared_ptr<Agent> > agents;
 
 	float ownerx = (seeing->x + (seeing->getWidth() / 2.0f));
 	float ownery = (seeing->y + (seeing->getHeight() / 2.0f));
 	MetaRoom *ownermeta = world.map.metaRoomAt(ownerx, ownery);
-	shared_ptr<Room> ownerroom = world.map.roomAt(ownerx, ownery);
+	std::shared_ptr<Room> ownerroom = world.map.roomAt(ownerx, ownery);
 	if (!ownermeta) return agents; if (!ownerroom) return agents;
 	
-	for (std::list<boost::shared_ptr<Agent> >::iterator i
+	for (std::list<std::shared_ptr<Agent> >::iterator i
 			= world.agents.begin(); i != world.agents.end(); i++) {
-		boost::shared_ptr<Agent> a = (*i);
+		std::shared_ptr<Agent> a = (*i);
 		if (!a) continue;
 		
 		// TODO: if owner is a creature, skip stuff with invisible attribute
@@ -115,9 +115,9 @@ bool agentsTouching(Agent *first, Agent *second) {
 	return true;
 }
 
-shared_ptr<Room> roomContainingAgent(AgentRef agent) {
+std::shared_ptr<Room> roomContainingAgent(AgentRef agent) {
 	MetaRoom *m = world.map.metaRoomAt(agent->x, agent->y);
-	if (!m) return shared_ptr<Room>();
+	if (!m) return std::shared_ptr<Room>();
 	return m->roomAt(agent->x + (agent->getWidth() / 2.0f), agent->y + (agent->getHeight() / 2.0f));
 }
 

--- a/src/AgentHelpers.h
+++ b/src/AgentHelpers.h
@@ -31,12 +31,12 @@ namespace boost {
 	template <typename T> class shared_ptr;
 }
 
-bool agentIsVisible(Agent *seeing, Agent *a, float ownerx, float ownery, MetaRoom *ownermeta, boost::shared_ptr<Room> ownerroom);
+bool agentIsVisible(Agent *seeing, Agent *a, float ownerx, float ownery, MetaRoom *ownermeta, std::shared_ptr<Room> ownerroom);
 bool agentIsVisible(Agent *seeing, Agent *dest);
-std::vector<boost::shared_ptr<Agent> > getVisibleList(Agent *seeing, unsigned char family, unsigned char genus, unsigned short species);
+std::vector<std::shared_ptr<Agent> > getVisibleList(Agent *seeing, unsigned char family, unsigned char genus, unsigned short species);
 
 bool agentsTouching(Agent *first, Agent *second);
-boost::shared_ptr<Room> roomContainingAgent(AgentRef agent);
+std::shared_ptr<Room> roomContainingAgent(AgentRef agent);
 
 #endif
 

--- a/src/AgentRef.cpp
+++ b/src/AgentRef.cpp
@@ -37,8 +37,8 @@ void AgentRef::dump() const {
 	std::cerr << "AgentRef " << (void *)this << " pointing to " << (void *)ref.lock().get() << std::endl;
 }
 
-boost::shared_ptr<Agent> AgentRef::lock() const {
-	boost::shared_ptr<Agent> p = ref.lock();
+std::shared_ptr<Agent> AgentRef::lock() const {
+	std::shared_ptr<Agent> p = ref.lock();
 	if (p && p->isDying())
 		p.reset();
 	return p;

--- a/src/AgentRef.h
+++ b/src/AgentRef.h
@@ -22,8 +22,7 @@
 
 #include <cstdlib> // for NULL
 #include <iostream>
-#include <boost/weak_ptr.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class Agent;
 
@@ -31,15 +30,15 @@ class AgentRef {
 	friend class Agent;
 	
 protected:
-	boost::weak_ptr<Agent> ref;
+	std::weak_ptr<Agent> ref;
 	void checkLife() const;
 
 public:
 	void dump() const;
 	
 	AgentRef() { }
-	AgentRef(boost::shared_ptr<Agent> a) { ref = a; }
-	AgentRef(boost::weak_ptr<Agent> a) { ref = a; }
+	AgentRef(std::shared_ptr<Agent> a) { ref = a; }
+	AgentRef(std::weak_ptr<Agent> a) { ref = a; }
 	AgentRef(Agent *a) { set(a); }
 	AgentRef(const AgentRef &r) : ref(r.ref) {}
 
@@ -62,10 +61,10 @@ public:
 
 	void set(Agent *a);
 	void set(const AgentRef &r) { ref = r.ref; }
-	void set(const boost::shared_ptr<Agent> &r) { ref = r; }
-	void set(const boost::weak_ptr<Agent> &r) { ref = r; }
+	void set(const std::shared_ptr<Agent> &r) { ref = r; }
+	void set(const std::weak_ptr<Agent> &r) { ref = r; }
 
-	boost::shared_ptr<Agent> lock() const;
+	std::shared_ptr<Agent> lock() const;
 	Agent *get() const { return lock().get(); }
 };
 		

--- a/src/AudioBackend.h
+++ b/src/AudioBackend.h
@@ -21,7 +21,7 @@
 #define SOUNDBACKEND_H 1
 
 #include <boost/intrusive_ptr.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/enable_shared_from_this.hpp>
 
 #include <string>
@@ -69,7 +69,7 @@ namespace boost {
  * The implementation should not make any assumptions about how often any of these functions
  * will be called, if at all.
  */
-typedef boost::shared_ptr<class AudioStreamBase> AudioStream;
+typedef std::shared_ptr<class AudioStreamBase> AudioStream;
 struct AudioStreamBase {
 	virtual ~AudioStreamBase() { }
 
@@ -144,12 +144,12 @@ public:
 	virtual bool isMuted() const = 0;
 
 	/* TODO: global vol controls */
-	virtual boost::shared_ptr<AudioSource> newSource() = 0;
+	virtual std::shared_ptr<AudioSource> newSource() = 0;
 	/* Returns an AudioSource with a fixed position relative to the viewpoint.
 	 *
 	 * The effect of invoking setPos on this source is undefined.
 	 */
-	virtual boost::shared_ptr<AudioSource> getBGMSource() = 0;
+	virtual std::shared_ptr<AudioSource> getBGMSource() = 0;
 	virtual AudioClip loadClip(const std::string &filename) = 0;
 
 	virtual void begin() { }

--- a/src/Backend.h
+++ b/src/Backend.h
@@ -21,10 +21,10 @@
 #define _BACKEND_H
 
 #include "endianlove.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 
-using boost::shared_ptr;
+using std::shared_ptr;
 
 enum eventtype { eventquit, eventkeydown, eventspecialkeyup, eventspecialkeydown, eventmousebuttondown, eventmousebuttonup, eventmousemove, eventresizewindow };
 enum eventbuttons { buttonleft=0x1, buttonright=0x2, buttonmiddle=0x4, buttonwheeldown=0x8, buttonwheelup=0x10 };
@@ -40,7 +40,7 @@ class creaturesImage;
 
 class Surface {
 public:
-	virtual void render(boost::shared_ptr<creaturesImage> image, unsigned int frame, int x, int y, bool trans = false, unsigned char transparency = 0, bool mirror = false, bool is_background = false) = 0;
+	virtual void render(std::shared_ptr<creaturesImage> image, unsigned int frame, int x, int y, bool trans = false, unsigned char transparency = 0, bool mirror = false, bool is_background = false) = 0;
 	virtual void renderLine(int x1, int y1, int x2, int y2, unsigned int colour) = 0;
 	virtual void renderText(int x, int y, std::string text, unsigned int colour, unsigned int bgcolour) = 0;
 	virtual void blitSurface(Surface *src, int x, int y, int w, int h) = 0;

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -80,12 +80,12 @@ class Backend;
 
 class MainCamera : public Camera {
 protected:
-	boost::shared_ptr<Backend> backend;
+	std::shared_ptr<Backend> backend;
 	std::vector<AgentRef> floated;
 
 public:
 	MainCamera() { }
-	void setBackend(boost::shared_ptr<Backend> b) { backend = b; }
+	void setBackend(std::shared_ptr<Backend> b) { backend = b; }
 	unsigned int getWidth() const;
 	unsigned int getHeight() const;
 	void moveTo(int _x, int _y, panstyle pan = jump);

--- a/src/CameraPart.h
+++ b/src/CameraPart.h
@@ -27,7 +27,7 @@ class Camera;
 class CameraPart : public SpritePart {
 protected:
 	unsigned int viewheight, viewwidth, cameraheight, camerawidth;
-	shared_ptr<Camera> camera;
+	std::shared_ptr<Camera> camera;
 	
 public:
 	CameraPart(Agent *p, unsigned int _id, std::string spritefile, unsigned int fimg, int _x, int _y,
@@ -36,7 +36,7 @@ public:
 
 	unsigned int cameraWidth() const { return viewwidth; }
 	unsigned int cameraHeight() const { return viewheight; }
-	shared_ptr<Camera> &getCamera() { return camera; }
+	std::shared_ptr<Camera> &getCamera() { return camera; }
 	void partRender(class Surface *renderer, int xoffset, int yoffset);
 	void tick();
 };

--- a/src/CompoundPart.cpp
+++ b/src/CompoundPart.cpp
@@ -44,7 +44,7 @@ bool partzorder::operator ()(const CompoundPart *s1, const CompoundPart *s2) con
 		return s1->getParent()->getZOrder() > s2->getParent()->getZOrder();
 }
 
-shared_ptr<creaturesImage> TextEntryPart::caretsprite;
+std::shared_ptr<creaturesImage> TextEntryPart::caretsprite;
 
 void CompoundPart::render(Surface *renderer, int xoffset, int yoffset) {
 	if (parent->visible) {
@@ -183,7 +183,7 @@ SpritePart::~SpritePart() {
 #include "images/bmpImage.h"
 
 void SpritePart::changeSprite(std::string spritefile, unsigned int fimg) {
-	shared_ptr<creaturesImage> spr = world.gallery.getImage(spritefile);
+	std::shared_ptr<creaturesImage> spr = world.gallery.getImage(spritefile);
 	caos_assert(spr);
 	base = 0; // TODO: should we preserve base?
 
@@ -203,7 +203,7 @@ void SpritePart::changeSprite(std::string spritefile, unsigned int fimg) {
 	setPose(pose); // TODO: we need to preserve pose, but shouldn't we do some sanity checking?
 }
 
-void SpritePart::changeSprite(shared_ptr<creaturesImage> spr) {
+void SpritePart::changeSprite(std::shared_ptr<creaturesImage> spr) {
 	caos_assert(spr);
 	// TODO: should we preserve tint?
 	base = 0; // TODO: should we preserve base?
@@ -542,7 +542,7 @@ void TextPart::partRender(Surface *renderer, int xoffset, int yoffset, TextEntry
 		currenty = (textheight - pageheights[currpage]) / 2;
 	unsigned int startline = pages[currpage];
 	unsigned int endline = (currpage + 1 < pages.size() ? pages[currpage + 1] : lines.size());
-	shared_ptr<creaturesImage> sprite = textsprite; unsigned int currtint = 0;
+	std::shared_ptr<creaturesImage> sprite = textsprite; unsigned int currtint = 0;
 	for (unsigned int i = startline; i < endline; i++) {	
 		unsigned int currentx = 0, somex = xoff;
 		if (horz_align == rightalign)
@@ -655,7 +655,7 @@ CameraPart::CameraPart(Agent *p, unsigned int _id, std::string spritefile, unsig
 	viewheight = view_height;
 	camerawidth = camera_width;
 	cameraheight = camera_height;
-	camera = shared_ptr<Camera>(new PartCamera(this));
+	camera = std::shared_ptr<Camera>(new PartCamera(this));
 }
 
 void CameraPart::partRender(class Surface *renderer, int xoffset, int yoffset) {

--- a/src/CompoundPart.h
+++ b/src/CompoundPart.h
@@ -96,7 +96,7 @@ public:
 
 class SpritePart : public AnimatablePart {
 protected:
-	shared_ptr<creaturesImage> origsprite, sprite;
+	std::shared_ptr<creaturesImage> origsprite, sprite;
 	unsigned int firstimg, pose, base, spriteno;
 	SpritePart(Agent *p, unsigned int _id, std::string spritefile, unsigned int fimg, int _x, int _y,
 				 unsigned int _z);
@@ -106,7 +106,7 @@ public:
 	bool draw_mirrored;
 	unsigned char framerate;
 	unsigned int framedelay;
-	shared_ptr<creaturesImage> getSprite() { return sprite; }
+	std::shared_ptr<creaturesImage> getSprite() { return sprite; }
 	virtual void partRender(class Surface *renderer, int xoffset, int yoffset);
 	virtual void tick();
 	unsigned int getPose() { return pose; }
@@ -120,7 +120,7 @@ public:
 	void setFramerate(unsigned char f) { framerate = f; framedelay = 0; }
 	void setBase(unsigned int b);
 	void changeSprite(std::string spritefile, unsigned int fimg);
-	void changeSprite(shared_ptr<creaturesImage> spr);
+	void changeSprite(std::shared_ptr<creaturesImage> spr);
 	void tint(unsigned char r, unsigned char g, unsigned char b, unsigned char rotation, unsigned char swap);
 	virtual bool isTransparent() { return is_transparent; }
 	bool transparentAt(unsigned int x, unsigned int y);
@@ -160,7 +160,7 @@ struct linedata {
 };
 
 struct texttintinfo {
-	shared_ptr<creaturesImage> sprite;
+	std::shared_ptr<creaturesImage> sprite;
 	unsigned int offset;
 };
 
@@ -176,7 +176,7 @@ protected:
 	unsigned int currpage;
 	std::string text;
 	
-	shared_ptr<creaturesImage> textsprite;
+	std::shared_ptr<creaturesImage> textsprite;
 	
 	int leftmargin, topmargin, rightmargin, bottommargin;
 	int linespacing, charspacing;
@@ -215,7 +215,7 @@ public:
 
 class TextEntryPart : public TextPart {
 private:
-	static shared_ptr<creaturesImage> caretsprite;
+	static std::shared_ptr<creaturesImage> caretsprite;
 	unsigned int caretpose;
 	bool focused;
 	unsigned int caretpos;

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -72,29 +72,29 @@ Engine::Engine() {
 	palette = 0;
 	exefile = 0;
 
-	addPossibleBackend("null", shared_ptr<Backend>(new NullBackend()));
-	addPossibleAudioBackend("null", shared_ptr<AudioBackend>(new NullAudioBackend()));
+	addPossibleBackend("null", std::shared_ptr<Backend>(new NullBackend()));
+	addPossibleAudioBackend("null", std::shared_ptr<AudioBackend>(new NullAudioBackend()));
 }
 
 Engine::~Engine() {
 	if (palette) delete[] palette;
 }
 
-void Engine::addPossibleBackend(std::string s, boost::shared_ptr<Backend> b) {
+void Engine::addPossibleBackend(std::string s, std::shared_ptr<Backend> b) {
 	assert(!backend);
 	assert(b);
 	preferred_backend = s;
 	possible_backends[s] = b;
 }
 
-void Engine::addPossibleAudioBackend(std::string s, boost::shared_ptr<AudioBackend> b) {
+void Engine::addPossibleAudioBackend(std::string s, std::shared_ptr<AudioBackend> b) {
 	assert(!audio);
 	assert(b);
 	preferred_audiobackend = s;
 	possible_audiobackends[s] = b;
 }
 
-void Engine::setBackend(shared_ptr<Backend> b) {
+void Engine::setBackend(std::shared_ptr<Backend> b) {
 	backend = b;
 	lasttimestamp = backend->ticks();
 }
@@ -213,7 +213,7 @@ void Engine::update() {
 	if (version == 1 && (world.tickcount % 70) == 0) {
 		int piece = 1 + (rand() % 28);
 		std::string filename = boost::str(boost::format("MU%02d") % piece);
-		boost::shared_ptr<AudioSource> s = world.playAudio(filename, AgentRef(), false, false, true);
+		std::shared_ptr<AudioSource> s = world.playAudio(filename, AgentRef(), false, false, true);
 		if (s) s->setVolume(0.4f);
 	}
 
@@ -359,7 +359,7 @@ void Engine::processEvents() {
 
 void Engine::handleResizedWindow(SomeEvent &event) {
 	// notify agents
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
 		if (!*i) continue;
 		(*i)->queueScript(123, 0); // window resized script
 	}
@@ -370,7 +370,7 @@ void Engine::handleMouseMove(SomeEvent &event) {
 	world.hand()->handleEvent(event);
 
 	// notify agents
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
 		if (!*i) continue;
 		if ((*i)->imsk_mouse_move) {
 			caosVar x; x.setFloat(world.hand()->pointerX());
@@ -382,7 +382,7 @@ void Engine::handleMouseMove(SomeEvent &event) {
 
 void Engine::handleMouseButton(SomeEvent &event) {
 	// notify agents
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
 		if (!*i) continue;
 		if ((event.type == eventmousebuttonup && (*i)->imsk_mouse_up) ||
 			(event.type == eventmousebuttondown && (*i)->imsk_mouse_down)) {
@@ -444,7 +444,7 @@ void Engine::handleKeyDown(SomeEvent &event) {
 	// notify agents
 	caosVar k;
 	k.setInt(event.key);
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
 		if (!*i) continue;
 		if ((*i)->imsk_translated_char)
 			(*i)->queueScript(79, 0, k); // translated char script
@@ -537,7 +537,7 @@ void Engine::handleSpecialKeyDown(SomeEvent &event) {
 	// notify agents
 	caosVar k;
 	k.setInt(event.key);
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
 		if (!*i) continue;
 		if ((*i)->imsk_key_down)
 			(*i)->queueScript(73, 0, k); // key down script
@@ -561,14 +561,14 @@ bool Engine::parseCommandLine(int argc, char *argv[]) {
 
 	// generate help for backend options
 	std::string available_backends;
-	for (std::map<std::string, boost::shared_ptr<Backend> >::iterator i = possible_backends.begin(); i != possible_backends.end(); i++) {
+	for (std::map<std::string, std::shared_ptr<Backend> >::iterator i = possible_backends.begin(); i != possible_backends.end(); i++) {
 		if (available_backends.empty()) available_backends = i->first;
 		else available_backends += ", " + i->first;
 	}
 	available_backends = "Select the backend (options: " + available_backends + "), default is " + preferred_backend;
 	
 	std::string available_audiobackends;
-	for (std::map<std::string, boost::shared_ptr<AudioBackend> >::iterator i = possible_audiobackends.begin(); i != possible_audiobackends.end(); i++) {
+	for (std::map<std::string, std::shared_ptr<AudioBackend> >::iterator i = possible_audiobackends.begin(); i != possible_audiobackends.end(); i++) {
 		if (available_audiobackends.empty()) available_audiobackends = i->first;
 		else available_audiobackends += ", " + i->first;
 	}
@@ -721,20 +721,20 @@ bool Engine::initialSetup() {
 
 	if (cmdline_norun) preferred_backend = "null";
 	if (preferred_backend != "null") std::cout << "* Initialising backend " << preferred_backend << "..." << std::endl;	
-	shared_ptr<Backend> b = possible_backends[preferred_backend];
+	std::shared_ptr<Backend> b = possible_backends[preferred_backend];
 	if (!b)	throw creaturesException("No such backend " + preferred_backend);
 	b->init(); setBackend(b);
 	possible_backends.clear();
 
 	if (cmdline_norun || !cmdline_enable_sound) preferred_audiobackend = "null";
 	if (preferred_audiobackend != "null") std::cout << "* Initialising audio backend " << preferred_audiobackend << "..." << std::endl;	
-	shared_ptr<AudioBackend> a = possible_audiobackends[preferred_audiobackend];
+	std::shared_ptr<AudioBackend> a = possible_audiobackends[preferred_audiobackend];
 	if (!a)	throw creaturesException("No such audio backend " + preferred_audiobackend);
 	try{
 		a->init(); audio = a;
 	} catch (creaturesException &e) {
 		std::cerr << "* Couldn't initialize backend " << preferred_audiobackend << ": " << e.what() << std::endl << "* Continuing without sound." << std::endl;
-		audio = shared_ptr<AudioBackend>(new NullAudioBackend());
+		audio = std::shared_ptr<AudioBackend>(new NullAudioBackend());
 		audio->init();
 	}
 	possible_audiobackends.clear();

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -44,8 +44,8 @@ protected:
 
 	std::string gamename;
 
-	std::map<std::string, boost::shared_ptr<Backend> > possible_backends;
-	std::map<std::string, boost::shared_ptr<class AudioBackend> > possible_audiobackends;
+	std::map<std::string, std::shared_ptr<Backend> > possible_backends;
+	std::map<std::string, std::shared_ptr<class AudioBackend> > possible_audiobackends;
 	std::string preferred_backend, preferred_audiobackend;
 
 	void handleKeyboardScrolling();
@@ -62,8 +62,8 @@ protected:
 public:
 	std::map<caosVar, caosVar, caosVarCompare> eame_variables; // non-serialised
 	
-	boost::shared_ptr<Backend> backend;
-	boost::shared_ptr<class AudioBackend> audio;
+	std::shared_ptr<Backend> backend;
+	std::shared_ptr<class AudioBackend> audio;
 	std::string getBackendName() { return preferred_backend; }
 	std::string getAudioBackendName() { return preferred_audiobackend; }
 
@@ -80,7 +80,7 @@ public:
 
 	Engine();
 	~Engine();
-	void setBackend(boost::shared_ptr<Backend> b);
+	void setBackend(std::shared_ptr<Backend> b);
 	std::string executeNetwork(std::string in);
 	bool needsUpdate();
 	unsigned int msUntilTick();
@@ -89,8 +89,8 @@ public:
 	bool tick();
 	void processEvents();
 
-	void addPossibleBackend(std::string, boost::shared_ptr<Backend>);
-	void addPossibleAudioBackend(std::string, boost::shared_ptr<AudioBackend>);
+	void addPossibleBackend(std::string, std::shared_ptr<Backend>);
+	void addPossibleAudioBackend(std::string, std::shared_ptr<AudioBackend>);
 	
 	bool parseCommandLine(int argc, char *argv[]);
 	bool initialSetup();

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -56,11 +56,11 @@ MetaRoom *Map::getMetaRoom(unsigned int room) {
 	return 0;
 }
 
-shared_ptr<Room> Map::getRoom(unsigned int r) {
-	for (std::vector<shared_ptr<Room> >::iterator i = rooms.begin(); i != rooms.end(); i++)
+std::shared_ptr<Room> Map::getRoom(unsigned int r) {
+	for (std::vector<std::shared_ptr<Room> >::iterator i = rooms.begin(); i != rooms.end(); i++)
 		if ((*i)->id == r)
 			return *i;
-	return shared_ptr<Room>();
+	return std::shared_ptr<Room>();
 }
 
 unsigned int Map::getMetaRoomCount() {
@@ -76,13 +76,13 @@ void Map::tick() {
 
 	// Three passes..
 	for (std::vector<MetaRoom *>::iterator m = metarooms.begin(); m != metarooms.end(); m++)
-		for (std::vector<shared_ptr<Room> >::iterator i = (*m)->rooms.begin(); i != (*m)->rooms.end(); i++)
+		for (std::vector<std::shared_ptr<Room> >::iterator i = (*m)->rooms.begin(); i != (*m)->rooms.end(); i++)
 			(*i)->tick();
 	for (std::vector<MetaRoom *>::iterator m = metarooms.begin(); m != metarooms.end(); m++)
-		for (std::vector<shared_ptr<Room> >::iterator i = (*m)->rooms.begin(); i != (*m)->rooms.end(); i++)
+		for (std::vector<std::shared_ptr<Room> >::iterator i = (*m)->rooms.begin(); i != (*m)->rooms.end(); i++)
 			(*i)->postTick();
 	for (std::vector<MetaRoom *>::iterator m = metarooms.begin(); m != metarooms.end(); m++)
-		for (std::vector<shared_ptr<Room> >::iterator i = (*m)->rooms.begin(); i != (*m)->rooms.end(); i++)
+		for (std::vector<std::shared_ptr<Room> >::iterator i = (*m)->rooms.begin(); i != (*m)->rooms.end(); i++)
 			(*i)->resetTick();
 }
 
@@ -96,20 +96,20 @@ MetaRoom *Map::metaRoomAt(unsigned int _x, unsigned int _y) {
 	return 0;
 }
 
-shared_ptr<Room> Map::roomAt(float _x, float _y) {
+std::shared_ptr<Room> Map::roomAt(float _x, float _y) {
 	MetaRoom *m = metaRoomAt((unsigned int)_x, (unsigned int)_y); // TODO: good casts?
-	if (!m) return shared_ptr<Room>();
+	if (!m) return std::shared_ptr<Room>();
 	return m->roomAt(_x, _y);
 }
 
-std::vector<shared_ptr<Room> > Map::roomsAt(float _x, float _y) {
+std::vector<std::shared_ptr<Room> > Map::roomsAt(float _x, float _y) {
 	MetaRoom *m = metaRoomAt((unsigned int)_x, (unsigned int)_y); // TODO: good casts?
-	if (!m) return std::vector<shared_ptr<Room> >();
+	if (!m) return std::vector<std::shared_ptr<Room> >();
 	return m->roomsAt(_x, _y);
 }
 
-bool Map::collideLineWithRoomSystem(Point src, Point dest, shared_ptr<Room> &room, Point &where, Line &wall, unsigned int &walldir, int perm) {
-	shared_ptr<Room> newRoom;
+bool Map::collideLineWithRoomSystem(Point src, Point dest, std::shared_ptr<Room> &room, Point &where, Line &wall, unsigned int &walldir, int perm) {
+	std::shared_ptr<Room> newRoom;
 
 	where = src;
 	
@@ -130,7 +130,7 @@ bool Map::collideLineWithRoomSystem(Point src, Point dest, shared_ptr<Room> &roo
 /*
  * poss. optimisation: skip checking the rest of the lines if our distance is 0?
  */
-bool Map::collideLineWithRoomBoundaries(Point src, Point dest, shared_ptr<Room> room, shared_ptr<Room> &newroom, Point &where, Line &wall, unsigned int &walldir, int perm) {
+bool Map::collideLineWithRoomBoundaries(Point src, Point dest, std::shared_ptr<Room> room, std::shared_ptr<Room> &newroom, Point &where, Line &wall, unsigned int &walldir, int perm) {
 	assert(room);
 	// TODO: this assert fails. why? 'where' is presumably outside the dest room sometimes.. mmh
 	//assert(room->containsPoint(src.x, src.y));
@@ -197,11 +197,11 @@ bool Map::collideLineWithRoomBoundaries(Point src, Point dest, shared_ptr<Room> 
 				continue; // continue, bad collision
 			}
 
-			shared_ptr<Room> nextroom;
+			std::shared_ptr<Room> nextroom;
 			bool foundroom = false;
 
-			for (std::map<boost::weak_ptr<Room>,RoomDoor *>::iterator r = room->doors.begin(); r != room->doors.end(); r++) {
-				shared_ptr<Room> otherroom = r->first.lock();
+			for (std::map<std::weak_ptr<Room>,RoomDoor *>::iterator r = room->doors.begin(); r != room->doors.end(); r++) {
+				std::shared_ptr<Room> otherroom = r->first.lock();
 				assert(otherroom);
 				assert(r->second);
 				if (otherroom->containsPoint(newx, newy)) {
@@ -225,7 +225,7 @@ bool Map::collideLineWithRoomBoundaries(Point src, Point dest, shared_ptr<Room> 
 				}
 			}*/
 		
-			shared_ptr<Room> z = roomAt(temppoint.x, temppoint.y); // TODO: evil performance-killing debug check
+			std::shared_ptr<Room> z = roomAt(temppoint.x, temppoint.y); // TODO: evil performance-killing debug check
 			if (!z) {
 				// TODO: commented out this error message for sake of fuzzie's sanity, but it's still an issue
 				/*std::cout << "physics bug: fell out of room system at (" << where.x << ", " << where.y << ")" << std::endl;

--- a/src/Map.h
+++ b/src/Map.h
@@ -32,7 +32,7 @@ protected:
 	FRIEND_SERIALIZE(Map)
 	unsigned int width, height;
 	std::vector<MetaRoom *> metarooms;
-	std::vector<shared_ptr<Room> > rooms;
+	std::vector<std::shared_ptr<Room> > rooms;
 
 	friend class MetaRoom;
 
@@ -59,15 +59,15 @@ public:
 	MetaRoom *getArrayMetaRoom(unsigned int i) { return metarooms[i]; } // TODO: hack!
 	
 	unsigned int getMetaRoomCount();
-	shared_ptr<Room> getRoom(unsigned int);
+	std::shared_ptr<Room> getRoom(unsigned int);
 	unsigned int getRoomCount();
 
 	MetaRoom *metaRoomAt(unsigned int, unsigned int);
-	shared_ptr<Room> roomAt(float, float);
-	std::vector<shared_ptr<Room> > roomsAt(float, float);
+	std::shared_ptr<Room> roomAt(float, float);
+	std::vector<std::shared_ptr<Room> > roomsAt(float, float);
 
-	bool collideLineWithRoomSystem(Point src, Point dest, shared_ptr<Room> &room, Point &where, Line &wall, unsigned int &walldir, int perm);
-	bool collideLineWithRoomBoundaries(Point src, Point dest, shared_ptr<Room> room, shared_ptr<Room> &newroom, Point &where, Line &wall, unsigned int &walldir, int perm);
+	bool collideLineWithRoomSystem(Point src, Point dest, std::shared_ptr<Room> &room, Point &where, Line &wall, unsigned int &walldir, int perm);
+	bool collideLineWithRoomBoundaries(Point src, Point dest, std::shared_ptr<Room> room, std::shared_ptr<Room> &newroom, Point &where, Line &wall, unsigned int &walldir, int perm);
 
 	void tick();
 };

--- a/src/MetaRoom.cpp
+++ b/src/MetaRoom.cpp
@@ -25,7 +25,7 @@
 #include <assert.h>
 #include "Backend.h"
 
-MetaRoom::MetaRoom(int _x, int _y, int _width, int _height, const std::string &back, shared_ptr<creaturesImage> spr, bool wrap) {
+MetaRoom::MetaRoom(int _x, int _y, int _width, int _height, const std::string &back, std::shared_ptr<creaturesImage> spr, bool wrap) {
 	xloc = _x; yloc = _y; wid = _width; hei = _height; wraps = wrap;
 
 	// if we were provided with a background, add it
@@ -38,8 +38,8 @@ MetaRoom::MetaRoom(int _x, int _y, int _width, int _height, const std::string &b
 	}
 }
 
-void MetaRoom::addBackground(std::string back, shared_ptr<creaturesImage> spr) {
-	shared_ptr<creaturesImage> backsprite;
+void MetaRoom::addBackground(std::string back, std::shared_ptr<creaturesImage> spr) {
+	std::shared_ptr<creaturesImage> backsprite;
 	unsigned int totalwidth, totalheight;
 
 	caos_assert(!back.empty());
@@ -87,19 +87,19 @@ std::vector<std::string> MetaRoom::backgroundList() {
 	// construct a temporary vector from our std::map
 
 	std::vector<std::string> b;
-	for (std::map<std::string, shared_ptr<creaturesImage> >::iterator i = backgrounds.begin(); i != backgrounds.end(); i++)
+	for (std::map<std::string, std::shared_ptr<creaturesImage> >::iterator i = backgrounds.begin(); i != backgrounds.end(); i++)
 		b.push_back(i->first);
 	return b;
 }
 
-shared_ptr<creaturesImage> MetaRoom::getBackground(std::string back) {
+std::shared_ptr<creaturesImage> MetaRoom::getBackground(std::string back) {
 	// return the first background by default
 	if (back.empty()) {
 		return firstback;
 	}
 	
 	// if this background name isn't found, return null
-	if (backgrounds.find(back) != backgrounds.end()) return shared_ptr<creaturesImage>();
+	if (backgrounds.find(back) != backgrounds.end()) return std::shared_ptr<creaturesImage>();
 	
 	// otherwise, return the relevant background
 	return backgrounds[back];
@@ -109,10 +109,10 @@ MetaRoom::~MetaRoom() {
 	// we hold the only strong reference to our contained rooms, so they'll be auto-deleted
 }
 
-shared_ptr<Room> MetaRoom::nextFloorFromPoint(float x, float y) {
-	shared_ptr<Room> closest_up, closest_down;
+std::shared_ptr<Room> MetaRoom::nextFloorFromPoint(float x, float y) {
+	std::shared_ptr<Room> closest_up, closest_down;
 	float dist_down = -1, dist_up = -1;
-	for (std::vector<shared_ptr<Room> >::iterator r = rooms.begin(); r != rooms.end(); r++) {
+	for (std::vector<std::shared_ptr<Room> >::iterator r = rooms.begin(); r != rooms.end(); r++) {
 		if (!(*r)->bot.containsX(x)) continue;
 		float dist = (*r)->bot.pointAtX(x).y - y; // down is positive
 		float absdist = fabs(dist);
@@ -126,10 +126,10 @@ shared_ptr<Room> MetaRoom::nextFloorFromPoint(float x, float y) {
 	}
 	if (closest_down) return closest_down;
 	if (closest_up) return closest_up;
-	return shared_ptr<Room>();
+	return std::shared_ptr<Room>();
 }
 
-unsigned int MetaRoom::addRoom(shared_ptr<Room> r) {
+unsigned int MetaRoom::addRoom(std::shared_ptr<Room> r) {
 	// add to both our local list and the global list
 	rooms.push_back(r);
 	world.map.rooms.push_back(r);
@@ -139,30 +139,30 @@ unsigned int MetaRoom::addRoom(shared_ptr<Room> r) {
 	return r->id;
 }
 
-shared_ptr<Room> MetaRoom::roomAt(float _x, float _y) {
+std::shared_ptr<Room> MetaRoom::roomAt(float _x, float _y) {
 	if (wraps) {
 		if (_x > (int)xloc + (int)wid) _x -= wid;
 		else if (_x < (int)xloc) _x += wid;
 	}
 
-	for (std::vector<shared_ptr<Room> >::iterator i = rooms.begin(); i != rooms.end(); i++) {
-		shared_ptr<Room> r = *i;
+	for (std::vector<std::shared_ptr<Room> >::iterator i = rooms.begin(); i != rooms.end(); i++) {
+		std::shared_ptr<Room> r = *i;
 		if (r->containsPoint(_x, _y)) return r;
 	}
 
-	return shared_ptr<Room>();
+	return std::shared_ptr<Room>();
 }
 
-std::vector<shared_ptr<Room> > MetaRoom::roomsAt(float _x, float _y) {
+std::vector<std::shared_ptr<Room> > MetaRoom::roomsAt(float _x, float _y) {
 	if (wraps) {
 		if (_x > (int)xloc + (int)wid) _x -= wid;
 		else if (_x < (int)xloc) _x += wid;
 	}
 
-	std::vector<shared_ptr<Room> > ourlist;
+	std::vector<std::shared_ptr<Room> > ourlist;
 
-	for (std::vector<shared_ptr<Room> >::iterator i = rooms.begin(); i != rooms.end(); i++) {
-		shared_ptr<Room> r = *i;
+	for (std::vector<std::shared_ptr<Room> >::iterator i = rooms.begin(); i != rooms.end(); i++) {
+		std::shared_ptr<Room> r = *i;
 		if (r->containsPoint(_x, _y)) ourlist.push_back(r);
 	}
 

--- a/src/MetaRoom.h
+++ b/src/MetaRoom.h
@@ -31,14 +31,14 @@ class MetaRoom {
 protected:
 	FRIEND_SERIALIZE(MetaRoom)
 	unsigned int xloc, yloc, wid, hei, fullwid, fullhei;
-	std::map<std::string, shared_ptr<creaturesImage> > backgrounds;
-	shared_ptr<creaturesImage> firstback;
+	std::map<std::string, std::shared_ptr<creaturesImage> > backgrounds;
+	std::shared_ptr<creaturesImage> firstback;
 	bool wraps;
 	
 	MetaRoom() { }
 
 public:
-	std::vector<shared_ptr<class Room> > rooms;
+	std::vector<std::shared_ptr<class Room> > rooms;
 
 	unsigned int x() { return xloc; }
 	unsigned int y() { return yloc; }
@@ -49,21 +49,21 @@ public:
 	bool wraparound() { return wraps; }
 	void setWraparound(bool w) { wraps = !!w; }
 
-	unsigned int addRoom(shared_ptr<class Room>);
-	void addBackground(std::string, shared_ptr<creaturesImage> = shared_ptr<creaturesImage>());
-	shared_ptr<creaturesImage> getBackground(std::string);
+	unsigned int addRoom(std::shared_ptr<class Room>);
+	void addBackground(std::string, std::shared_ptr<creaturesImage> = std::shared_ptr<creaturesImage>());
+	std::shared_ptr<creaturesImage> getBackground(std::string);
 	std::vector<std::string> backgroundList();
 
-	shared_ptr<Room> nextFloorFromPoint(float x, float y);
+	std::shared_ptr<Room> nextFloorFromPoint(float x, float y);
 
-	shared_ptr<Room> roomAt(float x, float y);
-	std::vector<shared_ptr<Room> > roomsAt(float x, float y);
+	std::shared_ptr<Room> roomAt(float x, float y);
+	std::vector<std::shared_ptr<Room> > roomsAt(float x, float y);
 
 	std::string music;
 
 	unsigned int id;
 
-	MetaRoom(int _x, int _y, int width, int height, const std::string &back, shared_ptr<creaturesImage> = shared_ptr<creaturesImage>(), bool wrap = false);
+	MetaRoom(int _x, int _y, int width, int height, const std::string &back, std::shared_ptr<creaturesImage> = std::shared_ptr<creaturesImage>(), bool wrap = false);
 	~MetaRoom();
 };
 

--- a/src/MusicManager.cpp
+++ b/src/MusicManager.cpp
@@ -65,7 +65,7 @@ void MusicManager::tick() {
 		// TODO: this behaviour is different in C2, and should probably be cleverer
 		MetaRoom *m = world.camera->getMetaRoom();
 		if (m) {
-			shared_ptr<Room> r = m->roomAt(world.camera->getXCentre(), world.camera->getYCentre());
+			std::shared_ptr<Room> r = m->roomAt(world.camera->getXCentre(), world.camera->getYCentre());
 			if (r && r->music.size()) {
 				playTrack(r->music, 0);
 			} else if (m->music.size()) {
@@ -146,13 +146,13 @@ void MusicManager::playTrack(std::string track, unsigned int latency) {
 		return; // TODO: exception?
 	}
 
-	shared_ptr<MusicTrack> tracknode(new MusicTrack(file, file->tracks[trackname]));
+	std::shared_ptr<MusicTrack> tracknode(new MusicTrack(file, file->tracks[trackname]));
 	tracknode->init();
 	playTrack(tracknode);
 	current_latency = latency;
 }
 
-void MusicManager::playTrack(shared_ptr<MusicTrack> track) {
+void MusicManager::playTrack(std::shared_ptr<MusicTrack> track) {
 	playing_silence = false;
 	track->startFadeIn();
 	if (!currenttrack) {
@@ -166,13 +166,13 @@ void MusicManager::playTrack(shared_ptr<MusicTrack> track) {
 }
 
 void MusicManager::startPlayback() {
-	shared_ptr<AudioSource> src = engine.audio->getBGMSource();
+	std::shared_ptr<AudioSource> src = engine.audio->getBGMSource();
 	if (!src) return;
 
 	if (!stream) {
 		// we assume no-one else ever steals the BGM stream from
 		// under us, but what are we meant to do then anyway?
-		stream = shared_ptr<MusicStream>(new MusicStream);
+		stream = std::shared_ptr<MusicStream>(new MusicStream);
 		src->setStream(stream);
 		src->play();
 	}
@@ -374,7 +374,7 @@ MusicEffect::MusicEffect(MNGEffectDecNode *n) {
 	node = n;
 
 	for (std::list<MNGStageNode *>::iterator i = node->children->begin(); i != node->children->end(); i++) {
-		shared_ptr<MusicStage> stage(new MusicStage(*i));
+		std::shared_ptr<MusicStage> stage(new MusicStage(*i));
 		stages.push_back(stage);
 	}
 }
@@ -382,7 +382,7 @@ MusicEffect::MusicEffect(MNGEffectDecNode *n) {
 std::vector<FloatAudioBuffer> MusicEffect::applyEffect(class MusicTrack *t, std::vector<FloatAudioBuffer> src, float beatlength) {
 	std::vector<FloatAudioBuffer> buffers;
 
-	for (std::vector<shared_ptr<MusicStage> >::iterator i = stages.begin(); i != stages.end(); i++) {
+	for (std::vector<std::shared_ptr<MusicStage> >::iterator i = stages.begin(); i != stages.end(); i++) {
 		std::vector<FloatAudioBuffer> newbuffers = (*i)->applyStage(src, beatlength);
 		for (std::vector<FloatAudioBuffer>::iterator j = newbuffers.begin(); j != newbuffers.end(); j++) {
 			buffers.push_back(*j);
@@ -392,7 +392,7 @@ std::vector<FloatAudioBuffer> MusicEffect::applyEffect(class MusicTrack *t, std:
 	return buffers;
 }
 
-MusicVoice::MusicVoice(shared_ptr<MusicLayer> p, MNGVoiceNode *n) {
+MusicVoice::MusicVoice(std::shared_ptr<MusicLayer> p, MNGVoiceNode *n) {
 	node = n;
 	parent = p.get();
 
@@ -408,7 +408,7 @@ MusicVoice::MusicVoice(shared_ptr<MusicLayer> p, MNGVoiceNode *n) {
 		MNGWaveNode *e = dynamic_cast<MNGWaveNode *>(n);
 		if (e) {
 			// TODO: share duplicate MusicWaves
-			wave = shared_ptr<MusicWave>(new MusicWave(p->getParent()->getParent(), e));
+			wave = std::shared_ptr<MusicWave>(new MusicWave(p->getParent()->getParent(), e));
 			continue;
 		}
 
@@ -441,7 +441,7 @@ MusicVoice::MusicVoice(shared_ptr<MusicLayer> p, MNGVoiceNode *n) {
 				throw MNGFileException("couldn't find effect '" + eff->getName() + "'");
 
 			MNGEffectDecNode *n = effects[eff->getName()];
-			effect = shared_ptr<MusicEffect>(new MusicEffect(n));
+			effect = std::shared_ptr<MusicEffect>(new MusicEffect(n));
 			continue;
 		}
 
@@ -460,7 +460,7 @@ bool MusicVoice::shouldPlay() {
 	return true;
 }
 
-MusicLayer::MusicLayer(shared_ptr<MusicTrack> p) {
+MusicLayer::MusicLayer(std::shared_ptr<MusicTrack> p) {
 	parent = p.get();
 
 	updaterate = 1.0f;
@@ -535,7 +535,7 @@ void MusicVoice::runUpdateBlock() {
 	}
 }
 
-MusicAleotoricLayer::MusicAleotoricLayer(MNGAleotoricLayerNode *n, shared_ptr<MusicTrack> p) : MusicLayer(p) {
+MusicAleotoricLayer::MusicAleotoricLayer(MNGAleotoricLayerNode *n, std::shared_ptr<MusicTrack> p) : MusicLayer(p) {
 	node = n;
 }
 
@@ -554,13 +554,13 @@ void MusicAleotoricLayer::init() {
 				throw MNGFileException("couldn't find effect '" + e->getName() + "'");
 
 			MNGEffectDecNode *n = effects[e->getName()];
-			effect = shared_ptr<MusicEffect>(new MusicEffect(n));
+			effect = std::shared_ptr<MusicEffect>(new MusicEffect(n));
 			continue;
 		}
 
 		MNGVoiceNode *v = dynamic_cast<MNGVoiceNode *>(n);
 		if (v) {
-			shared_ptr<MusicVoice> voice(new MusicVoice(shared_from_this(), v));
+			std::shared_ptr<MusicVoice> voice(new MusicVoice(shared_from_this(), v));
 			voices.push_back(voice);
 			continue;
 		}
@@ -618,13 +618,13 @@ void MusicAleotoricLayer::update(unsigned int latency) {
 	std::vector<FloatAudioBuffer> buffers;
 
 	float our_volume = volume * parent->getVolume();
-	for (std::vector<shared_ptr<MusicVoice> >::iterator i = voices.begin(); i != voices.end(); i++) {
+	for (std::vector<std::shared_ptr<MusicVoice> >::iterator i = voices.begin(); i != voices.end(); i++) {
 		if (!(*i)->shouldPlay()) continue;
 
 		if ((*i)->getWave()) {
 			FloatAudioBuffer &data = (*i)->getWave()->getData();
 			FloatAudioBuffer voicebuffer = FloatAudioBuffer(data.data, data.len, offset, our_volume, pan);
-			shared_ptr<MusicEffect> voice_effect = (*i)->getEffect();
+			std::shared_ptr<MusicEffect> voice_effect = (*i)->getEffect();
 			if (voice_effect) {
 				std::vector<FloatAudioBuffer> newbuffers;
 				newbuffers.push_back(voicebuffer);
@@ -658,7 +658,7 @@ void MusicAleotoricLayer::update(unsigned int latency) {
 	next_offset = offset;
 }
 
-MusicLoopLayer::MusicLoopLayer(MNGLoopLayerNode *n, shared_ptr<MusicTrack> p) : MusicLayer(p) {
+MusicLoopLayer::MusicLoopLayer(MNGLoopLayerNode *n, std::shared_ptr<MusicTrack> p) : MusicLayer(p) {
 	node = n;
 	update_period = 0;
 }
@@ -670,7 +670,7 @@ void MusicLoopLayer::init() {
 		MNGWaveNode *e = dynamic_cast<MNGWaveNode *>(n);
 		if (e) {
 			// TODO: share duplicate MusicWaves
-			wave = shared_ptr<MusicWave>(new MusicWave(parent->getParent(), e));
+			wave = std::shared_ptr<MusicWave>(new MusicWave(parent->getParent(), e));
 			continue;
 		}
 
@@ -743,7 +743,7 @@ void MusicTrack::init() {
 		MNGAleotoricLayerNode *al = dynamic_cast<MNGAleotoricLayerNode *>(n);
 		if (al) {
 			MusicAleotoricLayer *ptr = new MusicAleotoricLayer(al, shared_from_this());
-			shared_ptr<MusicLayer> mal(ptr);
+			std::shared_ptr<MusicLayer> mal(ptr);
 			ptr->init();
 			layers.push_back(mal);
 			continue;
@@ -752,7 +752,7 @@ void MusicTrack::init() {
 		MNGLoopLayerNode *ll = dynamic_cast<MNGLoopLayerNode *>(n);
 		if (ll) {
 			MusicLoopLayer *ptr = new MusicLoopLayer(ll, shared_from_this());
-			shared_ptr<MusicLayer> mll(ptr);
+			std::shared_ptr<MusicLayer> mll(ptr);
 			ptr->init();
 			layers.push_back(mll);
 			continue;
@@ -790,7 +790,7 @@ MusicTrack::~MusicTrack() {
 }
 
 void MusicTrack::update(unsigned int latency) {
-	for (std::vector<shared_ptr<MusicLayer> >::iterator i = layers.begin(); i != layers.end(); i++) {
+	for (std::vector<std::shared_ptr<MusicLayer> >::iterator i = layers.begin(); i != layers.end(); i++) {
 		(*i)->update(latency);
 	}
 }

--- a/src/MusicManager.h
+++ b/src/MusicManager.h
@@ -22,23 +22,23 @@
 
 #include "music/mngfile.h"
 #include "endianlove.h"
-#include <boost/shared_ptr.hpp>
-using boost::shared_ptr;
+#include <memory>
+using std::shared_ptr;
 #include <boost/enable_shared_from_this.hpp>
 
 class MusicManager {
 private:
 	std::map<std::string, MNGFile *> files;
 
-	shared_ptr<class MusicTrack> currenttrack, nexttrack;
+	std::shared_ptr<class MusicTrack> currenttrack, nexttrack;
 	bool playing_silence;
 	unsigned int current_latency;
 
-	shared_ptr<class MusicStream> stream;
+	std::shared_ptr<class MusicStream> stream;
 
 	void startPlayback();
 
-	void playTrack(shared_ptr<class MusicTrack> track);
+	void playTrack(std::shared_ptr<class MusicTrack> track);
 
 public:
 	MusicManager();
@@ -93,7 +93,7 @@ public:
 class MusicEffect {
 protected:
 	MNGEffectDecNode *node;
-	std::vector<shared_ptr<MusicStage> > stages;
+	std::vector<std::shared_ptr<MusicStage> > stages;
 
 public:
 	MusicEffect(MNGEffectDecNode *n);
@@ -105,8 +105,8 @@ protected:
 	MNGVoiceNode *node;
 	MNGUpdateNode *updatenode;
 	class MusicLayer *parent;
-	shared_ptr<MusicWave> wave;
-	shared_ptr<MusicEffect> effect;
+	std::shared_ptr<MusicWave> wave;
+	std::shared_ptr<MusicEffect> effect;
 
 	std::vector<MNGConditionNode *> conditions;
 
@@ -114,11 +114,11 @@ protected:
 	float interval, volume;
 
 public:
-	MusicVoice(shared_ptr<class MusicLayer> p, MNGVoiceNode *n);
-	shared_ptr<MusicWave> getWave() { return wave; }
+	MusicVoice(std::shared_ptr<class MusicLayer> p, MNGVoiceNode *n);
+	std::shared_ptr<MusicWave> getWave() { return wave; }
 	float getInterval() { return interval; }
 	float getVolume() { return volume; }
-	shared_ptr<MusicEffect> getEffect() { return effect; }
+	std::shared_ptr<MusicEffect> getEffect() { return effect; }
 	bool shouldPlay();
 	void runUpdateBlock();
 	MusicLayer *getParent() { return parent; }
@@ -134,7 +134,7 @@ protected:
 	std::map<std::string, float> variables;
 	float updaterate, volume, interval, beatsynch, pan;
 
-	MusicLayer(shared_ptr<MusicTrack> p);
+	MusicLayer(std::shared_ptr<MusicTrack> p);
 	void runUpdateBlock();
 
 public:
@@ -150,11 +150,11 @@ class MusicAleotoricLayer : public MusicLayer {
 protected:
 	MNGAleotoricLayerNode *node;
 
-	shared_ptr<MusicEffect> effect;
-	std::vector<shared_ptr<MusicVoice> > voices;
+	std::shared_ptr<MusicEffect> effect;
+	std::vector<std::shared_ptr<MusicVoice> > voices;
 
 public:
-	MusicAleotoricLayer(MNGAleotoricLayerNode *n, shared_ptr<MusicTrack> p);
+	MusicAleotoricLayer(MNGAleotoricLayerNode *n, std::shared_ptr<MusicTrack> p);
 	void init();
 	void update(unsigned int latency);
 };
@@ -164,10 +164,10 @@ protected:
 	MNGLoopLayerNode *node;
 
 	unsigned int update_period;
-	shared_ptr<MusicWave> wave;
+	std::shared_ptr<MusicWave> wave;
 
 public:
-	MusicLoopLayer(MNGLoopLayerNode *n, shared_ptr<MusicTrack> p);
+	MusicLoopLayer(MNGLoopLayerNode *n, std::shared_ptr<MusicTrack> p);
 	void init();
 	void update(unsigned int latency);
 };
@@ -177,7 +177,7 @@ protected:
 	MNGTrackDecNode *node;
 	MNGFile *parent;
 
-	std::vector<shared_ptr<MusicLayer> > layers;
+	std::vector<std::shared_ptr<MusicLayer> > layers;
 
 	float fadein, fadeout, beatlength, volume;
 

--- a/src/PointerAgent.cpp
+++ b/src/PointerAgent.cpp
@@ -68,7 +68,7 @@ void PointerAgent::drop(AgentRef a) {
 // TODO: this should have a queueScript equiv too
 void PointerAgent::firePointerScript(unsigned short event, Agent *src) {
 	assert(src); // TODO: I /think/ this should only be called by the engine..
-	shared_ptr<script> s = src->findScript(event);
+	std::shared_ptr<script> s = src->findScript(event);
 	if (!s && engine.version < 3) { // TODO: are we sure this doesn't apply to c2e?
 		s = findScript(event); // TODO: we should make sure this actually belongs to the pointer agent and isn't a fallback, maybe
 	}
@@ -212,7 +212,7 @@ void PointerAgent::handleEvent(SomeEvent &event) {
 			
 				bool foundport = false;
 				if (engine.version > 2) {
-					for (std::map<unsigned int, boost::shared_ptr<OutputPort> >::iterator i = parent->outports.begin();
+					for (std::map<unsigned int, std::shared_ptr<OutputPort> >::iterator i = parent->outports.begin();
 							 i != parent->outports.end(); i++) {
 						// TODO: 4 is a magic number i pulled out of nooooowhere
 						if (abs(i->second->x + parent->x - x) < 4 && abs(i->second->y + parent->y - y) < 4) {
@@ -231,7 +231,7 @@ void PointerAgent::handleEvent(SomeEvent &event) {
 						}
 					}
 					if (!foundport) {
-						for (std::map<unsigned int, boost::shared_ptr<InputPort> >::iterator i = parent->inports.begin();
+						for (std::map<unsigned int, std::shared_ptr<InputPort> >::iterator i = parent->inports.begin();
 								 i != parent->inports.end(); i++) {
 							// TODO: 4 is a magic number i pulled out of nooooowhere
 							if (abs(i->second->x + parent->x - x) < 4 && abs(i->second->y + parent->y - y) < 4) {
@@ -326,7 +326,7 @@ void PointerAgent::handleEvent(SomeEvent &event) {
 					// ensure there's a room to drop into, in C1
 					MetaRoom* m = world.map.metaRoomAt(x, y);
 					if (!m) return;
-					shared_ptr<Room> r = m->nextFloorFromPoint(x, y);
+					std::shared_ptr<Room> r = m->nextFloorFromPoint(x, y);
 					if (!r) return;
 
 					carrying->queueScript(5, this); // drop
@@ -340,7 +340,7 @@ void PointerAgent::handleEvent(SomeEvent &event) {
 					/* check dropstatus for the room we're dropping into */
 					MetaRoom* m = world.map.metaRoomAt(carrying->x, carrying->y);
 					if (m) {
-						shared_ptr<Room> r = m->roomAt(carrying->x, carrying->y);
+						std::shared_ptr<Room> r = m->roomAt(carrying->x, carrying->y);
 						if (r) {
 							if (r->dropstatus == 0) allowdrop = false; // Never
 							else if (r->dropstatus == 1) { // Above-Floor
@@ -392,7 +392,7 @@ void PointerAgent::handleEvent(SomeEvent &event) {
 				}
 			}
 		} else if (event.button == buttonmiddle) {
-			std::vector<shared_ptr<Room> > rooms = world.map.roomsAt(x, y);
+			std::vector<std::shared_ptr<Room> > rooms = world.map.roomsAt(x, y);
 			if (rooms.size() > 0) std::cout << "Room at cursor is " << rooms[0]->id << std::endl;
 			Agent *a = world.agentAt(x, y, true);
 			if (a)

--- a/src/Room.cpp
+++ b/src/Room.cpp
@@ -95,8 +95,8 @@ void Room::postTick() {
 
 	// adjust for diffusion to/from surrounding rooms
 	// TODO: absolutely no clue if this is correct
-	for (std::map<boost::weak_ptr<Room>,RoomDoor *>::iterator d = doors.begin(); d != doors.end(); d++) {
-		shared_ptr<Room> dest = d->second->first.lock();
+	for (std::map<std::weak_ptr<Room>,RoomDoor *>::iterator d = doors.begin(); d != doors.end(); d++) {
+		std::shared_ptr<Room> dest = d->second->first.lock();
 		if (dest.get() == this) dest = d->second->second.lock();
 		assert(dest);
 

--- a/src/Room.h
+++ b/src/Room.h
@@ -27,20 +27,20 @@
 #include "caosVar.h"
 #include <iostream>
 #include <algorithm>
-#include <boost/weak_ptr.hpp>
+#include <memory>
 
 using std::cerr;
 
 #define CA_COUNT 20
 
 struct RoomDoor {
-	boost::weak_ptr<class Room> first, second;
+	std::weak_ptr<class Room> first, second;
 	unsigned short perm;
 };
 
 class Room {
 public:
-	std::map<boost::weak_ptr<Room>,RoomDoor *> doors;
+	std::map<std::weak_ptr<Room>,RoomDoor *> doors;
 	unsigned int x_left, x_right, y_left_ceiling, y_right_ceiling;
 	unsigned int y_left_floor, y_right_floor;
 	

--- a/src/SFCFile.cpp
+++ b/src/SFCFile.cpp
@@ -806,8 +806,8 @@ void SFCFile::copyToWorld() {
 	// patch agents
 	// TODO: do we really need to do this, and if so, should it be done here?
 	// I like this for now because it makes debugging suck a lot less - fuzzie
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
-		boost::shared_ptr<Agent> a = (*i);
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+		std::shared_ptr<Agent> a = (*i);
 
 		#define NUM_SFC_PATCHES 5
 
@@ -846,7 +846,7 @@ void SFCFile::copyToWorld() {
 
 void MapData::copyToWorld() {
 	// find the background sprite
-	shared_ptr<creaturesImage> spr = world.gallery.getImage(background->filename);
+	std::shared_ptr<creaturesImage> spr = world.gallery.getImage(background->filename);
 	sfccheck(spr);
 
 	// check for Terra Nornia's corrupt background sprite
@@ -870,7 +870,7 @@ void MapData::copyToWorld() {
 		CRoom *src = *i;
 
 		// create a new room, set the type
-		shared_ptr<Room> r(new Room(src->left, src->right, src->top, src->top, src->bottom, src->bottom));
+		std::shared_ptr<Room> r(new Room(src->left, src->right, src->top, src->top, src->bottom, src->bottom));
 		r->type.setInt(src->roomtype);
 
 		// add the room to the world, ensure it matches the id we retrieved
@@ -919,8 +919,8 @@ void MapData::copyToWorld() {
 		for (unsigned int j = 0; j < 4; j++) {
 			for (std::vector<CDoor *>::iterator k = src->doors[j].begin(); k < src->doors[j].end(); k++) {
 				CDoor *door = *k;
-				shared_ptr<Room> r1 = world.map.getRoom(src->id);
-				shared_ptr<Room> r2 = world.map.getRoom(door->otherroom);
+				std::shared_ptr<Room> r1 = world.map.getRoom(src->id);
+				std::shared_ptr<Room> r2 = world.map.getRoom(door->otherroom);
 		
 				if (r1->doors.find(r2) == r1->doors.end()) {
 					// create a new door between rooms!

--- a/src/Scriptorium.cpp
+++ b/src/Scriptorium.cpp
@@ -25,19 +25,19 @@ inline unsigned int Scriptorium::calculateValue(unsigned char family, unsigned c
 	return (family + (genus << 8) + (species << 16));
 }
 
-void Scriptorium::addScript(unsigned char family, unsigned char genus, unsigned short species, unsigned short event, shared_ptr<script> s) {
-	std::map<unsigned short, shared_ptr<script> > &m = getScripts(calculateValue(family, genus, species));
+void Scriptorium::addScript(unsigned char family, unsigned char genus, unsigned short species, unsigned short event, std::shared_ptr<script> s) {
+	std::map<unsigned short, std::shared_ptr<script> > &m = getScripts(calculateValue(family, genus, species));
 	m[event] = s;
 }
 
 void Scriptorium::delScript(unsigned char family, unsigned char genus, unsigned short species, unsigned short event) {
 	// Retrieve the list of scripts for the classifier, return if there aren't any.
-	std::map<unsigned int, std::map<unsigned short, shared_ptr<script> > >::iterator x = scripts.find(calculateValue(family, genus, species));
+	std::map<unsigned int, std::map<unsigned short, std::shared_ptr<script> > >::iterator x = scripts.find(calculateValue(family, genus, species));
 	if (x == scripts.end())
 		return;
 
 	// Retrieve the script, return if it doesn't exist.
-	std::map<unsigned short, shared_ptr<script> >::iterator j = x->second.find(event);
+	std::map<unsigned short, std::shared_ptr<script> >::iterator j = x->second.find(event);
 	if (j == x->second.end())
 		return;
 
@@ -49,16 +49,16 @@ void Scriptorium::delScript(unsigned char family, unsigned char genus, unsigned 
 		scripts.erase(x);
 }
 
-shared_ptr<script> Scriptorium::getScript(unsigned char family, unsigned char genus, unsigned short species, unsigned short event) {
-	std::map<unsigned short, shared_ptr<script> > &x = getScripts(calculateValue(family, genus, species));
+std::shared_ptr<script> Scriptorium::getScript(unsigned char family, unsigned char genus, unsigned short species, unsigned short event) {
+	std::map<unsigned short, std::shared_ptr<script> > &x = getScripts(calculateValue(family, genus, species));
 	if (x.find(event) == x.end()) {
-		std::map<unsigned short, shared_ptr<script> > &x = getScripts(calculateValue(family, genus, 0));
+		std::map<unsigned short, std::shared_ptr<script> > &x = getScripts(calculateValue(family, genus, 0));
 		if (x.find(event) == x.end()) {
-			std::map<unsigned short, shared_ptr<script> > &x = getScripts(calculateValue(family, 0, 0));
+			std::map<unsigned short, std::shared_ptr<script> > &x = getScripts(calculateValue(family, 0, 0));
 			if (x.find(event) == x.end()) {
-				std::map<unsigned short, shared_ptr<script> > &x = getScripts(calculateValue(0, 0, 0));
+				std::map<unsigned short, std::shared_ptr<script> > &x = getScripts(calculateValue(0, 0, 0));
 				if (x.find(event) == x.end()) {
-					return shared_ptr<script>();
+					return std::shared_ptr<script>();
 				} else return x[event];
 			} else return x[event];
 		} else return x[event];

--- a/src/Scriptorium.h
+++ b/src/Scriptorium.h
@@ -22,8 +22,8 @@
 #define _SCRIPTORIUM_H
 
 #include "openc2e.h"
-#include <boost/shared_ptr.hpp>
-using boost::shared_ptr;
+#include <memory>
+using std::shared_ptr;
 #include <map>
 
 class script;
@@ -33,15 +33,15 @@ protected:
 	FRIEND_SERIALIZE(Scriptorium)
 	// unsigned int = combined family/genus/species
 	// unsigned short = event id
-	std::map<unsigned int, std::map<unsigned short, shared_ptr<script> > > scripts;
+	std::map<unsigned int, std::map<unsigned short, std::shared_ptr<script> > > scripts;
 	
-	std::map<unsigned short, shared_ptr<script> > &getScripts(unsigned int value) { return scripts[value]; }
+	std::map<unsigned short, std::shared_ptr<script> > &getScripts(unsigned int value) { return scripts[value]; }
 	unsigned int calculateValue(unsigned char family, unsigned char genus, unsigned short species);
 
 public:
-	void addScript(unsigned char family, unsigned char genus, unsigned short species, unsigned short event, shared_ptr<script> s);
+	void addScript(unsigned char family, unsigned char genus, unsigned short species, unsigned short event, std::shared_ptr<script> s);
 	void delScript(unsigned char family, unsigned char genus, unsigned short species, unsigned short event);
-	shared_ptr<script> getScript(unsigned char family, unsigned char genus, unsigned short species, unsigned short event);
+	std::shared_ptr<script> getScript(unsigned char family, unsigned char genus, unsigned short species, unsigned short event);
 };
 
 #endif

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -71,7 +71,7 @@ void World::init() {
 	if (engine.version > 2 && catalogue.hasTag("Pointer Information")) {
 		const std::vector<std::string> &pointerinfo = catalogue.getTag("Pointer Information");
 		if (pointerinfo.size() >= 3) {
-			shared_ptr<creaturesImage> img = gallery.getImage(pointerinfo[2]);
+			std::shared_ptr<creaturesImage> img = gallery.getImage(pointerinfo[2]);
 			if (img) {
 				theHand = new PointerAgent(pointerinfo[2]);
 				int family, genus, species;
@@ -97,7 +97,7 @@ void World::init() {
 	
 	// If for some reason we failed to do that (missing/bad catalogue tag? missing file?), try falling back to a sane default.
 	if (!theHand) {
-		shared_ptr<creaturesImage> img;
+		std::shared_ptr<creaturesImage> img;
 		if (gametype == "c3")
 			img = gallery.getImage("hand"); // as used in C3 and DS
 		else
@@ -215,9 +215,9 @@ void World::tick() {
 	// Notify the audio backend about our current viewpoint center.
 	engine.audio->setViewpointCenter(camera->getXCentre(), camera->getYCentre());
 	
-	std::list<std::pair<boost::shared_ptr<AudioSource>, bool> >::iterator si = uncontrolled_sounds.begin();
+	std::list<std::pair<std::shared_ptr<AudioSource>, bool> >::iterator si = uncontrolled_sounds.begin();
 	while (si != uncontrolled_sounds.end()) {
-		std::list<std::pair<boost::shared_ptr<AudioSource>, bool> >::iterator next = si; next++;
+		std::list<std::pair<std::shared_ptr<AudioSource>, bool> >::iterator next = si; next++;
 		if (si->first->getState() != SS_PLAY) {
 			// sound is stopped, so release our reference
 			uncontrolled_sounds.erase(si);
@@ -240,11 +240,11 @@ void World::tick() {
 	musicmanager.tick();
 	
 	// Tick all agents, deleting as necessary.	
-	std::list<boost::shared_ptr<Agent> >::iterator i = agents.begin();
+	std::list<std::shared_ptr<Agent> >::iterator i = agents.begin();
 	while (i != agents.end()) {
-		boost::shared_ptr<Agent> a = *i;
+		std::shared_ptr<Agent> a = *i;
 		if (!a) {
-			std::list<boost::shared_ptr<Agent> >::iterator i2 = i;
+			std::list<std::shared_ptr<Agent> >::iterator i2 = i;
 			i2++;
 			agents.erase(i);
 			i = i2;
@@ -257,7 +257,7 @@ void World::tick() {
 	// Process the script queue.
 	std::list<scriptevent> newqueue;
 	for (std::list<scriptevent>::iterator i = scriptqueue.begin(); i != scriptqueue.end(); i++) {
-		boost::shared_ptr<Agent> agent = i->agent.lock();
+		std::shared_ptr<Agent> agent = i->agent.lock();
 		if (agent) {
 			if (engine.version < 3) {
 				// only try running a collision script if the agent doesn't have a running script
@@ -378,8 +378,8 @@ void World::freeUNID(int unid) {
 	unidmap.erase(unid);
 }
 
-shared_ptr<Agent> World::lookupUNID(int unid) {
-	if (unid == 0) return shared_ptr<Agent>();
+std::shared_ptr<Agent> World::lookupUNID(int unid) {
+	if (unid == 0) return std::shared_ptr<Agent>();
 	return unidmap[unid].lock();
 }
 
@@ -401,7 +401,7 @@ void World::drawWorld(Camera *cam, Surface *surface) {
 	}
 	int adjustx = cam->getX();
 	int adjusty = cam->getY();
-	shared_ptr<creaturesImage> bkgd = m->getBackground(""); // TODO
+	std::shared_ptr<creaturesImage> bkgd = m->getBackground(""); // TODO
 
 	// TODO: work out what c2e does when it doesn't have a background..
 	if (!bkgd) return;
@@ -453,10 +453,10 @@ void World::drawWorld(Camera *cam, Surface *surface) {
 
 	// render port connection lines. TODO: these should be rendered as some kind
 	// of renderable, not directly like this.
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
-		boost::shared_ptr<Agent> a = *i;
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+		std::shared_ptr<Agent> a = *i;
 		if (!a) continue;
-		for (std::map<unsigned int, boost::shared_ptr<OutputPort> >::iterator p = a->outports.begin();
+		for (std::map<unsigned int, std::shared_ptr<OutputPort> >::iterator p = a->outports.begin();
 		     p != a->outports.end(); p++) {
 			for (PortConnectionList::iterator c = p->second->dests.begin(); c != p->second->dests.end(); c++) {
 				if (!c->first) continue;
@@ -468,8 +468,8 @@ void World::drawWorld(Camera *cam, Surface *surface) {
 	}
 
 	if (showrooms) {
-		shared_ptr<Room> r = map.roomAt(hand()->x, hand()->y);
-		for (std::vector<shared_ptr<Room> >::iterator i = cam->getMetaRoom()->rooms.begin();
+		std::shared_ptr<Room> r = map.roomAt(hand()->x, hand()->y);
+		for (std::vector<std::shared_ptr<Room> >::iterator i = cam->getMetaRoom()->rooms.begin();
 				 i != cam->getMetaRoom()->rooms.end(); i++) {
 			unsigned int col = 0xFFFF00CC;
 			if (*i == r) col = 0xFF00FFCC;
@@ -646,14 +646,14 @@ std::string World::getUserDataDir() {
 	return (data_directories.end() - 1)->native_directory_string();
 }
 
-void World::selectCreature(boost::shared_ptr<Agent> a) {
+void World::selectCreature(std::shared_ptr<Agent> a) {
 	if (a) {
 		CreatureAgent *c = dynamic_cast<CreatureAgent *>(a.get());
 		caos_assert(c);
 	}
 
 	if (selectedcreature != a) {
-		for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+		for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
 			if (!*i) continue;
 			(*i)->queueScript(120, 0, caosVar(a), caosVar(selectedcreature)); // selected creature changed
 		}
@@ -662,12 +662,12 @@ void World::selectCreature(boost::shared_ptr<Agent> a) {
 	}
 }
 
-shared_ptr<genomeFile> World::loadGenome(std::string &genefile) {
+std::shared_ptr<genomeFile> World::loadGenome(std::string &genefile) {
 	std::vector<std::string> possibles = findFiles("/Genetics/", genefile + ".gen");
-	if (possibles.empty()) return shared_ptr<genomeFile>();
+	if (possibles.empty()) return std::shared_ptr<genomeFile>();
 	genefile = possibles[(int)((float)possibles.size() * (rand() / (RAND_MAX + 1.0)))];
 
-	shared_ptr<genomeFile> p(new genomeFile());
+	std::shared_ptr<genomeFile> p(new genomeFile());
 	std::ifstream gfile(genefile.c_str(), std::ios::binary);
 	caos_assert(gfile.is_open());
 	gfile >> std::noskipws;
@@ -676,7 +676,7 @@ shared_ptr<genomeFile> World::loadGenome(std::string &genefile) {
 	return p;
 }
 
-void World::newMoniker(shared_ptr<genomeFile> g, std::string genefile, AgentRef agent) {
+void World::newMoniker(std::shared_ptr<genomeFile> g, std::string genefile, AgentRef agent) {
 	std::string d = history.newMoniker(g);
 	world.history.getMoniker(d).addEvent(2, "", genefile);
 	world.history.getMoniker(d).moveToAgent(agent);
@@ -709,16 +709,16 @@ std::string World::generateMoniker(std::string basename) {
 	return x;
 }
 
-boost::shared_ptr<AudioSource> World::playAudio(std::string filename, AgentRef agent, bool controlled, bool loop, bool followviewport) {
-	if (filename.size() == 0) return boost::shared_ptr<AudioSource>();
+std::shared_ptr<AudioSource> World::playAudio(std::string filename, AgentRef agent, bool controlled, bool loop, bool followviewport) {
+	if (filename.size() == 0) return std::shared_ptr<AudioSource>();
 
-	boost::shared_ptr<AudioSource> sound = engine.audio->newSource();
-	if (!sound) return boost::shared_ptr<AudioSource>();
+	std::shared_ptr<AudioSource> sound = engine.audio->newSource();
+	if (!sound) return std::shared_ptr<AudioSource>();
 
 	AudioClip clip = engine.audio->loadClip(filename);
 	if (!clip) {
 		// note that more specific error messages can be thrown by implementations of loadClip
-		if (engine.version < 3) return boost::shared_ptr<AudioSource>(); // creatures 1 and 2 ignore non-existent audio clips
+		if (engine.version < 3) return std::shared_ptr<AudioSource>(); // creatures 1 and 2 ignore non-existent audio clips
 		throw creaturesException("failed to load audio clip " + filename);
 	}
 
@@ -736,13 +736,13 @@ boost::shared_ptr<AudioSource> World::playAudio(std::string filename, AgentRef a
 		if (controlled)
 			agent->sound = sound;
 		else
-			uncontrolled_sounds.push_back(std::pair<boost::shared_ptr<class AudioSource>, bool>(sound, false));
+			uncontrolled_sounds.push_back(std::pair<std::shared_ptr<class AudioSource>, bool>(sound, false));
 	} else {
 		assert(!controlled);
 
 		// TODO: handle non-agent sounds
 		sound->setPos(camera->getXCentre(), camera->getYCentre(), 0);
-		uncontrolled_sounds.push_back(std::pair<boost::shared_ptr<class AudioSource>, bool>(sound, followviewport));
+		uncontrolled_sounds.push_back(std::pair<std::shared_ptr<class AudioSource>, bool>(sound, followviewport));
 	}
 	
 	sound->play();

--- a/src/World.h
+++ b/src/World.h
@@ -51,9 +51,9 @@ protected:
 	class PointerAgent *theHand;
 	std::list<scriptevent> scriptqueue;
 	
-	std::list<std::pair<boost::shared_ptr<class AudioSource>, bool> > uncontrolled_sounds; // audio, followingviewport
+	std::list<std::pair<std::shared_ptr<class AudioSource>, bool> > uncontrolled_sounds; // audio, followingviewport
 	
-	std::map<int, boost::weak_ptr<Agent> > unidmap;
+	std::map<int, std::weak_ptr<Agent> > unidmap;
 	std::vector<caosVM *> vmpool;
 
 public:
@@ -64,7 +64,7 @@ public:
 
 	std::multiset<CompoundPart *, partzorder> zorder; // sorted from top to bottom
 	std::multiset<renderable *, renderablezorder> renders; // sorted from bottom to top
-	std::list<boost::shared_ptr<Agent> > agents;
+	std::list<std::shared_ptr<Agent> > agents;
 	
 	std::map<unsigned int, std::map<unsigned int, cainfo> > carates;
 	std::map<std::string, caosVar> variables;
@@ -87,7 +87,7 @@ public:
 	std::vector<unsigned int> groundlevels;
 
 	AgentRef selectedcreature;
-	void selectCreature(boost::shared_ptr<Agent> c);
+	void selectCreature(std::shared_ptr<Agent> c);
 	AgentRef focusagent; unsigned int focuspart;
 	void setFocus(class CompoundPart *p);
 
@@ -113,10 +113,10 @@ public:
 	std::string findFile(std::string path);
 	std::vector<std::string> findFiles(std::string dir, std::string wild);
 
-	boost::shared_ptr<AudioSource> playAudio(std::string filename, AgentRef agent, bool controlled, bool loop, bool followviewport = false);
+	std::shared_ptr<AudioSource> playAudio(std::string filename, AgentRef agent, bool controlled, bool loop, bool followviewport = false);
 
-	void newMoniker(shared_ptr<genomeFile> g, std::string genefile, AgentRef agent);
-	shared_ptr<genomeFile> loadGenome(std::string &filename);
+	void newMoniker(std::shared_ptr<genomeFile> g, std::string genefile, AgentRef agent);
+	std::shared_ptr<genomeFile> loadGenome(std::string &filename);
 	std::string generateMoniker(std::string basename);
 
 	int findCategory(unsigned char family, unsigned char genus, unsigned short species);
@@ -129,7 +129,7 @@ public:
 	void setUNID(Agent *whofor, int unid);
 	void freeUNID(int unid);
 
-	shared_ptr<Agent> lookupUNID(int unid);
+	std::shared_ptr<Agent> lookupUNID(int unid);
 };
 
 extern World world;

--- a/src/backends/NullAudioBackend.h
+++ b/src/backends/NullAudioBackend.h
@@ -34,11 +34,11 @@ public:
 	void setViewpointCenter(float, float) { }
 	void setMute(bool b) { muted = b; }
 	bool isMuted() const { return muted; }
-	boost::shared_ptr<AudioSource> newSource() { return boost::shared_ptr<AudioSource>(); }
+	std::shared_ptr<AudioSource> newSource() { return std::shared_ptr<AudioSource>(); }
 	AudioClip loadClip(const std::string &) { return AudioClip(); }
 
-	boost::shared_ptr<AudioSource> getBGMSource() {
-		return boost::shared_ptr<AudioSource>();
+	std::shared_ptr<AudioSource> getBGMSource() {
+		return std::shared_ptr<AudioSource>();
 	}
 };
  

--- a/src/backends/NullBackend.h
+++ b/src/backends/NullBackend.h
@@ -24,7 +24,7 @@
 
 class NullSurface : public Surface {
 public:
-	virtual void render(shared_ptr<creaturesImage> image, unsigned int frame, int x, int y, bool trans = false, unsigned char transparency = 0, bool mirror = false, bool is_background = false) { }
+	virtual void render(std::shared_ptr<creaturesImage> image, unsigned int frame, int x, int y, bool trans = false, unsigned char transparency = 0, bool mirror = false, bool is_background = false) { }
 	virtual void renderLine(int x1, int y1, int x2, int y2, unsigned int colour) { }
 	virtual void renderText(int x, int y, std::string text, unsigned int colour, unsigned int bgcolour) { }
 	virtual void blitSurface(Surface *src, int x, int y, int w, int h)  { }

--- a/src/backends/OpenALBackend.h
+++ b/src/backends/OpenALBackend.h
@@ -45,8 +45,8 @@ protected:
 
 	BufferList::iterator blit;
 
-	boost::weak_ptr<class OpenALBackend> backend;
-	OpenALBuffer(boost::shared_ptr<class OpenALBackend>, ALuint);
+	std::weak_ptr<class OpenALBackend> backend;
+	OpenALBuffer(std::shared_ptr<class OpenALBackend>, ALuint);
 	friend class OpenALBackend;
 	friend class OpenALSource;
 
@@ -71,7 +71,7 @@ namespace boost {
 	}
 }
 
-typedef boost::shared_ptr<class OpenALStreamBuf> OpenALStreamBufP;
+typedef std::shared_ptr<class OpenALStreamBuf> OpenALStreamBufP;
 class OpenALStreamBuf {
 	ALuint bufferID, format;
 	int freq, bitDepth, approx_ms;
@@ -92,9 +92,9 @@ protected:
 
 	SourceList::iterator slit;
 
-	boost::weak_ptr<class OpenALBackend> backend_weak;
-	boost::shared_ptr<class OpenALBackend> backend() const;
-	OpenALSource(boost::shared_ptr<class OpenALBackend>);
+	std::weak_ptr<class OpenALBackend> backend_weak;
+	std::shared_ptr<class OpenALBackend> backend() const;
+	OpenALSource(std::shared_ptr<class OpenALBackend>);
 	friend class OpenALBackend;
 
 	OpenALClip clip;
@@ -142,8 +142,8 @@ protected:
 	bool muted;
 
 	// these are weak to avoid a reference loop
-	std::map<OpenALSource *, boost::weak_ptr<AudioSource> > followingSrcs;
-	std::map<OpenALSource *, boost::weak_ptr<AudioSource> > pollingSrcs;
+	std::map<OpenALSource *, std::weak_ptr<AudioSource> > followingSrcs;
+	std::map<OpenALSource *, std::weak_ptr<AudioSource> > pollingSrcs;
 	friend class OpenALSource;
 	friend class OpenALBuffer;
 
@@ -156,14 +156,14 @@ protected:
 	void startPolling(OpenALSource *);
 	void stopPolling(OpenALSource *);
 
-	boost::shared_ptr<AudioSource> bgmSource;
+	std::shared_ptr<AudioSource> bgmSource;
 
 public:
-	boost::shared_ptr<OpenALBackend> shared_from_this() {
-		return boost::static_pointer_cast<OpenALBackend, AudioBackend>(this->AudioBackend::shared_from_this());
+	std::shared_ptr<OpenALBackend> shared_from_this() {
+		return std::static_pointer_cast<OpenALBackend, AudioBackend>(this->AudioBackend::shared_from_this());
 	}
-	boost::shared_ptr<const OpenALBackend> shared_from_this() const {
-		return boost::static_pointer_cast<const OpenALBackend, const AudioBackend>(this->AudioBackend::shared_from_this());
+	std::shared_ptr<const OpenALBackend> shared_from_this() const {
+		return std::static_pointer_cast<const OpenALBackend, const AudioBackend>(this->AudioBackend::shared_from_this());
 	}
 
 	OpenALBackend() { }
@@ -174,8 +174,8 @@ public:
 	void setMute(bool m);
 	bool isMuted() const { return muted; }
 
-	boost::shared_ptr<AudioSource> newSource();
-	boost::shared_ptr<AudioSource> getBGMSource();
+	std::shared_ptr<AudioSource> newSource();
+	std::shared_ptr<AudioSource> getBGMSource();
 	AudioClip loadClip(const std::string &filename);
 
 	void begin();

--- a/src/backends/SDLBackend.cpp
+++ b/src/backends/SDLBackend.cpp
@@ -351,7 +351,7 @@ SDL_Surface *MirrorSurface(SDL_Surface *surf, SDL_Color *surfpalette) {
 
 //*** end mirror code
 
-void SDLSurface::render(shared_ptr<creaturesImage> image, unsigned int frame, int x, int y, bool trans, unsigned char transparency, bool mirror, bool is_background) {
+void SDLSurface::render(std::shared_ptr<creaturesImage> image, unsigned int frame, int x, int y, bool trans, unsigned char transparency, bool mirror, bool is_background) {
 	assert(image);
 	assert(image->numframes() > frame);
 

--- a/src/backends/SDLBackend.h
+++ b/src/backends/SDLBackend.h
@@ -36,7 +36,7 @@ protected:
 	SDLSurface(SDLBackend *p) { parent = p; }
 
 public:
-	void render(shared_ptr<creaturesImage> image, unsigned int frame, int x, int y, bool trans = false, unsigned char transparency = 0, bool mirror = false, bool is_background = false);
+	void render(std::shared_ptr<creaturesImage> image, unsigned int frame, int x, int y, bool trans = false, unsigned char transparency = 0, bool mirror = false, bool is_background = false);
 	void renderLine(int x1, int y1, int x2, int y2, unsigned int colour);
 	void renderText(int x, int y, std::string text, unsigned int colour, unsigned int bgcolour);
 	void blitSurface(Surface *src, int x, int y, int w, int h);

--- a/src/backends/SDLMixerBackend.cpp
+++ b/src/backends/SDLMixerBackend.cpp
@@ -48,8 +48,8 @@ void SDLMixerBackend::setMute(bool m) {
 	muted = m;
 }
 
-boost::shared_ptr<AudioSource> SDLMixerBackend::newSource() {
-	return boost::shared_ptr<AudioSource>(new SDLMixerSource());
+std::shared_ptr<AudioSource> SDLMixerBackend::newSource() {
+	return std::shared_ptr<AudioSource>(new SDLMixerSource());
 }
 
 AudioClip SDLMixerBackend::loadClip(const std::string &filename) {

--- a/src/backends/SDLMixerBackend.h
+++ b/src/backends/SDLMixerBackend.h
@@ -105,12 +105,12 @@ public:
 	void setViewpointCenter(float, float);
 	void setMute(bool);
 	bool isMuted() const { return muted; }
-	boost::shared_ptr<AudioSource> newSource();
+	std::shared_ptr<AudioSource> newSource();
 	AudioClip loadClip(const std::string &);
 
-	boost::shared_ptr<AudioSource> getBGMSource() {
+	std::shared_ptr<AudioSource> getBGMSource() {
 		// STUB
-		return boost::shared_ptr<AudioSource>();
+		return std::shared_ptr<AudioSource>();
 	}
 };
 

--- a/src/backends/qtgui/Hatchery.cpp
+++ b/src/backends/qtgui/Hatchery.cpp
@@ -48,7 +48,7 @@
  * of the top-left pixel transparent. If makealpha is set, also apply
  * alpha transparency to the rest of the image.
  */
-QImage imageFromSpriteFrame(shared_ptr<creaturesImage> img, unsigned int frame, bool makealpha = false) {
+QImage imageFromSpriteFrame(std::shared_ptr<creaturesImage> img, unsigned int frame, bool makealpha = false) {
 	assert(img->format() == if_16bit);
 
 	// img->data is not 32-bit-aligned so we have to make a copy here.
@@ -164,7 +164,7 @@ public:
 // TODO: these are from imageManager.cpp, it'd be nice to have a non-hacky interface,
 // but we probably need to fix the image object model first due to endianism issues
 enum filetype { blk, s16, c16, spr, bmp };
-bool tryOpen(mmapifstream *in, shared_ptr<creaturesImage> &img, std::string fname, filetype ft);
+bool tryOpen(mmapifstream *in, std::shared_ptr<creaturesImage> &img, std::string fname, filetype ft);
 
 Hatchery::Hatchery(QtOpenc2e *parent) : QDialog(parent) {
 	qtopenc2e = parent;

--- a/src/backends/qtgui/Hatchery.h
+++ b/src/backends/qtgui/Hatchery.h
@@ -19,7 +19,7 @@
 
 #include <QDialog>
 #include <QPixmap>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class Hatchery : public QDialog {
 	Q_OBJECT
@@ -38,7 +38,7 @@ class Hatchery : public QDialog {
 		// unknown, male, female
 		QPixmap genderanim[3][16];
 
-		boost::shared_ptr<class creaturesImage> omelettedata;
+		std::shared_ptr<class creaturesImage> omelettedata;
 };
 
 #endif /* HATCHERY_H */

--- a/src/backends/qtgui/QtBackend.cpp
+++ b/src/backends/qtgui/QtBackend.cpp
@@ -317,7 +317,7 @@ bool QtBackend::keyDown(int key) {
 
 int QtBackend::run(int argc, char **argv) {
 	QApplication app(argc, argv);
-	boost::shared_ptr<QtBackend> qtbackend = boost::dynamic_pointer_cast<class QtBackend, class Backend>(engine.backend);
+	std::shared_ptr<QtBackend> qtbackend = std::dynamic_pointer_cast<class QtBackend, class Backend>(engine.backend);
 	assert(qtbackend.get() == this);
 
 	QtOpenc2e myvat(qtbackend);

--- a/src/backends/qtgui/openc2eview.cpp
+++ b/src/backends/qtgui/openc2eview.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-openc2eView::openc2eView(QWidget *parent, boost::shared_ptr<QtBackend> b) : QAbstractScrollArea(parent) {
+openc2eView::openc2eView(QWidget *parent, std::shared_ptr<QtBackend> b) : QAbstractScrollArea(parent) {
 	backend = b;
 
 	viewport()->setAttribute(Qt::WA_PaintOnScreen); // disable double-buffering
@@ -57,8 +57,8 @@ openc2eView::openc2eView(QWidget *parent, boost::shared_ptr<QtBackend> b) : QAbs
 openc2eView::~openc2eView() {
 }
 
-boost::shared_ptr<class Backend> openc2eView::getBackend() {
-	return boost::dynamic_pointer_cast<class Backend, class QtBackend>(backend);
+std::shared_ptr<class Backend> openc2eView::getBackend() {
+	return std::dynamic_pointer_cast<class Backend, class QtBackend>(backend);
 }
 
 void openc2eView::resizescrollbars() {

--- a/src/backends/qtgui/openc2eview.h
+++ b/src/backends/qtgui/openc2eview.h
@@ -18,14 +18,14 @@
 #define _OPENC2EVIEW_H
 
 #include <QAbstractScrollArea>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "Backend.h"
 
 class openc2eView : public QAbstractScrollArea {
 	Q_OBJECT
 
 public:
-	openc2eView(QWidget *parent, boost::shared_ptr<class QtBackend>);
+	openc2eView(QWidget *parent, std::shared_ptr<class QtBackend>);
 	~openc2eView();
 
 protected:
@@ -47,7 +47,7 @@ protected:
 	void scrollContentsBy(int dx, int dy);
 
 	// variables
-	boost::shared_ptr<class QtBackend> backend;
+	std::shared_ptr<class QtBackend> backend;
 	int lastmousex, lastmousey;
 	class MetaRoom *lastMetaroom;
 
@@ -55,7 +55,7 @@ protected:
 	void resizescrollbars();
 
 public:
-	boost::shared_ptr<class Backend> getBackend();
+	std::shared_ptr<class Backend> getBackend();
 	bool needsRender();
 	void tick();
 };

--- a/src/backends/qtgui/qtopenc2e.cpp
+++ b/src/backends/qtgui/qtopenc2e.cpp
@@ -72,7 +72,7 @@ QIcon iconFromImageList(QPixmap l, unsigned int n) {
 }
 
 // Constructor which creates the main window.
-QtOpenc2e::QtOpenc2e(boost::shared_ptr<QtBackend> backend) {
+QtOpenc2e::QtOpenc2e(std::shared_ptr<QtBackend> backend) {
 	viewport = new openc2eView(this, backend);
 	setCentralWidget(viewport);
 
@@ -436,7 +436,7 @@ QtOpenc2e::~QtOpenc2e() {
 }
 
 monikerData &monikerDataFor(AgentRef a) {
-	shared_ptr<class genomeFile> g = a->getSlot(0);
+	std::shared_ptr<class genomeFile> g = a->getSlot(0);
 	assert(g);
 	std::string moniker = world.history.findMoniker(g);
 	return world.history.getMoniker(moniker);
@@ -453,8 +453,8 @@ void QtOpenc2e::selectCreature() {
 
 	Agent *a = (Agent *)srcaction->data().value<void *>();
 
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
-		boost::shared_ptr<Agent> p = *i;
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+		std::shared_ptr<Agent> p = *i;
 		if (!p) continue; // grr, but needed
 
 		if (a == p.get()) {
@@ -469,8 +469,8 @@ void QtOpenc2e::selectCreature() {
 void QtOpenc2e::updateCreaturesMenu() {
 	creaturesMenu->clear();
 
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
-		boost::shared_ptr<Agent> p = *i;
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+		std::shared_ptr<Agent> p = *i;
 		if (!p) continue; // grr, but needed
 
 		CreatureAgent *a = dynamic_cast<CreatureAgent *>(p.get());
@@ -563,7 +563,7 @@ void QtOpenc2e::tick() {
 			}
 			yeartext->setText(boost::str(boost::format("Year: %03i") % (int)world.year).c_str());
 		
-			shared_ptr<Room> room_for_tempcheck;
+			std::shared_ptr<Room> room_for_tempcheck;
 			if (world.selectedcreature) { // prefer the room the selected creature is in
 				room_for_tempcheck = roomContainingAgent(world.selectedcreature);
 			}
@@ -674,8 +674,8 @@ void QtOpenc2e::updateAppletStatus() {
 
 		// update 'next creature' button depending on whether there's any creatures we can select
 		bool are_there_creatures_present = false;
-		for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
-			boost::shared_ptr<Agent> p = *i;
+		for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+			std::shared_ptr<Agent> p = *i;
 			if (!p) continue; // grr, but needed
 
 			CreatureAgent *a = dynamic_cast<CreatureAgent *>(p.get());
@@ -780,7 +780,7 @@ void QtOpenc2e::newNorn() {
 	if (engine.version > 2) return; // TODO: fixme
 
 	std::string genomefile = "test";
-	shared_ptr<genomeFile> genome;
+	std::shared_ptr<genomeFile> genome;
 	try {
 		genome = world.loadGenome(genomefile);
 	} catch (creaturesException &e) {

--- a/src/backends/qtgui/qtopenc2e.h
+++ b/src/backends/qtgui/qtopenc2e.h
@@ -18,14 +18,14 @@
 #define _QTOPENC2E_H
 
 #include <QMainWindow>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "AgentRef.h"
 
 class QtOpenc2e : public QMainWindow {
 	Q_OBJECT
 
 public:
-	QtOpenc2e(boost::shared_ptr<class QtBackend>);
+	QtOpenc2e(std::shared_ptr<class QtBackend>);
 	~QtOpenc2e();
 
 	class Creature *getSelectedCreature();

--- a/src/caos/caosVM_agent.cpp
+++ b/src/caos/caosVM_agent.cpp
@@ -86,8 +86,8 @@ void caosVM::c_RTAR() {
 	setTarg(0);
 
 	/* XXX: maybe use a map of classifier -> agents? */
-	std::vector<boost::shared_ptr<Agent> > temp;
-	for (std::list<boost::shared_ptr<Agent> >::iterator i
+	std::vector<std::shared_ptr<Agent> > temp;
+	for (std::list<std::shared_ptr<Agent> >::iterator i
 		= world.agents.begin(); i != world.agents.end(); i++) {
 		
 		Agent *a = i->get();
@@ -123,8 +123,8 @@ void caosVM::c_TTAR() {
 	setTarg(0);
 
 	/* XXX: maybe use a map of classifier -> agents? */
-	std::vector<boost::shared_ptr<Agent> > temp;
-	for (std::list<boost::shared_ptr<Agent> >::iterator i
+	std::vector<std::shared_ptr<Agent> > temp;
+	for (std::list<std::shared_ptr<Agent> >::iterator i
 		= world.agents.begin(); i != world.agents.end(); i++) {
 		
 		Agent *a = i->get();
@@ -163,7 +163,7 @@ void caosVM::c_STAR() {
 	if (owner) seeing = owner; else seeing = targ;
 	valid_agent(seeing);
 
-	std::vector<boost::shared_ptr<Agent> > agents = getVisibleList(seeing, family, genus, species);
+	std::vector<std::shared_ptr<Agent> > agents = getVisibleList(seeing, family, genus, species);
 	if (agents.size() == 0) {
 		setTarg(0);
 	} else {
@@ -900,7 +900,7 @@ void caosVM::v_TOTL() {
 	VM_PARAM_INTEGER(family) caos_assert(family >= 0); caos_assert(family <= 255);
 
 	unsigned int x = 0;
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
 		if (!*i) continue;
 		if ((*i)->family == family || family == 0)
 			if ((*i)->genus == genus || genus == 0)
@@ -1599,7 +1599,7 @@ AgentRef findNextAgent(AgentRef previous, unsigned char family, unsigned char ge
 	AgentRef firstagent;
 	bool foundagent = false;
 
-	std::list<boost::shared_ptr<Agent> >::iterator i;
+	std::list<std::shared_ptr<Agent> >::iterator i;
 	if (forward)
 		i = world.agents.begin();
 	else {
@@ -1830,7 +1830,7 @@ void caosVM::v_LIML() {
 		Vehicle *v = dynamic_cast<Vehicle *>(targ->invehicle.get()); assert(v);
 		result.setInt((int)v->x + v->cabinleft);
 	} else {
-		shared_ptr<Room> r = world.map.roomAt(targ->x + (targ->getWidth() / 2.0f), targ->y + (targ->getHeight() / 2.0f));
+		std::shared_ptr<Room> r = world.map.roomAt(targ->x + (targ->getWidth() / 2.0f), targ->y + (targ->getHeight() / 2.0f));
 
 		if (r) result.setInt(r->x_left);
 		else result.setInt(0);
@@ -1850,7 +1850,7 @@ void caosVM::v_LIMT() {
 		Vehicle *v = dynamic_cast<Vehicle *>(targ->invehicle.get()); assert(v);
 		result.setInt((int)v->y + v->cabintop);
 	} else {
-		shared_ptr<Room> r = world.map.roomAt(targ->x + (targ->getWidth() / 2.0f), targ->y + (targ->getHeight() / 2.0f));
+		std::shared_ptr<Room> r = world.map.roomAt(targ->x + (targ->getWidth() / 2.0f), targ->y + (targ->getHeight() / 2.0f));
 
 		if (r) result.setInt(r->y_left_ceiling);
 		else result.setInt(0);
@@ -1870,7 +1870,7 @@ void caosVM::v_LIMR() {
 		Vehicle *v = dynamic_cast<Vehicle *>(targ->invehicle.get()); assert(v);
 		result.setInt((int)v->x + v->cabinright);
 	} else {
-		shared_ptr<Room> r = world.map.roomAt(targ->x + (targ->getWidth() / 2.0f), targ->y + (targ->getHeight() / 2.0f));
+		std::shared_ptr<Room> r = world.map.roomAt(targ->x + (targ->getWidth() / 2.0f), targ->y + (targ->getHeight() / 2.0f));
 
 		if (r) result.setInt(r->x_right);
 		else result.setInt(8352); // TODO
@@ -1891,7 +1891,7 @@ void caosVM::v_LIMB_c1() {
 		Vehicle *v = dynamic_cast<Vehicle *>(targ->invehicle.get()); assert(v);
 		result.setInt((int)v->y + v->cabinbottom);
 	} else {
-		shared_ptr<Room> r = world.map.roomAt(targ->x + (targ->getWidth() / 2.0f), targ->y + (targ->getHeight() / 2.0f));
+		std::shared_ptr<Room> r = world.map.roomAt(targ->x + (targ->getWidth() / 2.0f), targ->y + (targ->getHeight() / 2.0f));
 
 		if (r) result.setInt(r->y_left_floor);
 		else result.setInt(1200); // TODO
@@ -2039,7 +2039,7 @@ void caosVM::c_BLCK() {
 
 	SpritePart *p = getCurrentSpritePart();
 	caos_assert(p);
-	shared_ptr<creaturesImage> i = p->getSprite();
+	std::shared_ptr<creaturesImage> i = p->getSprite();
 	bmpImage *img = dynamic_cast<bmpImage *>(i.get());
 	caos_assert(img);
 

--- a/src/caos/caosVM_creatures.cpp
+++ b/src/caos/caosVM_creatures.cpp
@@ -615,9 +615,9 @@ void caosVM::c_URGE_SIGN() {
 	stim.verb_id = verb_id;
 	stim.verb_amount = verb_stim;
 
-	std::vector<boost::shared_ptr<Agent> > agents = getVisibleList(owner, 0, 0, 0);
-	for (std::vector<boost::shared_ptr<Agent> >::iterator i = agents.begin(); i != agents.end(); i++) {
-		boost::shared_ptr<Agent> a = *i; // guaranteed to be valid from getVisibleList
+	std::vector<std::shared_ptr<Agent> > agents = getVisibleList(owner, 0, 0, 0);
+	for (std::vector<std::shared_ptr<Agent> >::iterator i = agents.begin(); i != agents.end(); i++) {
+		std::shared_ptr<Agent> a = *i; // guaranteed to be valid from getVisibleList
 
 		CreatureAgent *ca = dynamic_cast<CreatureAgent *>(a.get());
 		if (!ca) continue;
@@ -1096,7 +1096,7 @@ void caosVM::c_NEWC() {
 
 	// TODO: creation should be blocking and multiple-tick!
 
-	std::map<unsigned int, shared_ptr<class genomeFile> >::iterator i = gene_agent->genome_slots.find(gene_slot);
+	std::map<unsigned int, std::shared_ptr<class genomeFile> >::iterator i = gene_agent->genome_slots.find(gene_slot);
 	caos_assert(i != gene_agent->genome_slots.end());
 
 	// randomise sex if necessary
@@ -1153,7 +1153,7 @@ void caosVM::c_NEW_CREA_c1() {
 	caos_assert(moniker != 0);
 
 	std::string realmoniker = std::string((char *)&moniker, 4);
-	shared_ptr<genomeFile> genome = world.loadGenome(realmoniker);
+	std::shared_ptr<genomeFile> genome = world.loadGenome(realmoniker);
 	if (!genome)
 		throw creaturesException("failed to find genome file '" + realmoniker + "'");
 
@@ -1202,7 +1202,7 @@ void caosVM::c_NEW_CRAG() {
 	VM_PARAM_VALIDAGENT(gene_agent)
 	VM_PARAM_INTEGER(family)
 
-       	std::map<unsigned int, shared_ptr<class genomeFile> >::iterator i = gene_agent->genome_slots.find(gene_slot);
+       	std::map<unsigned int, std::shared_ptr<class genomeFile> >::iterator i = gene_agent->genome_slots.find(gene_slot);
 	caos_assert(i != gene_agent->genome_slots.end());
 
 	// randomise sex if necessary
@@ -1411,7 +1411,7 @@ void caosVM::v_ORGF() {
 		return;
 	}
 	
-	shared_ptr<c2eOrgan> o = c->getOrgan(organ);
+	std::shared_ptr<c2eOrgan> o = c->getOrgan(organ);
 
 	switch (value) {
 		case 0: result.setFloat(o->getClockRate()); break;
@@ -1447,7 +1447,7 @@ void caosVM::v_ORGI() {
 		return;
 	}
 	
-	shared_ptr<c2eOrgan> o = c->getOrgan(organ);
+	std::shared_ptr<c2eOrgan> o = c->getOrgan(organ);
 
 	switch (value) {
 		case 0: result.setInt(o->getReceptorCount()); break;

--- a/src/caos/caosVM_debug.cpp
+++ b/src/caos/caosVM_debug.cpp
@@ -253,7 +253,7 @@ void caosVM::c_DBG_DISA() {
 	
 	caos_assert(outputstream);
 
-	shared_ptr<script> s = world.scriptorium.getScript(family, genus, species, event);
+	std::shared_ptr<script> s = world.scriptorium.getScript(family, genus, species, event);
 	if (s) {
 		if (s->fmly != family || s->gnus != genus || s->spcs != species) {
 			*outputstream << "warning: search resulted in script from " << s->fmly << ", " << s->gnus << ", " << s->spcs << " script" << std::endl;

--- a/src/caos/caosVM_flow.cpp
+++ b/src/caos/caosVM_flow.cpp
@@ -222,9 +222,9 @@ void caosVM::c_ENUM() {
 	caosVar nullv; nullv.reset();
 	valueStack.push_back(nullv);
 	
-	for (std::list<boost::shared_ptr<Agent> >::iterator i
+	for (std::list<std::shared_ptr<Agent> >::iterator i
 			= world.agents.begin(); i != world.agents.end(); i++) {
-		boost::shared_ptr<Agent> a = (*i);
+		std::shared_ptr<Agent> a = (*i);
 		if (!a) continue;
 		if (species && species != a->species) continue;
 		if (genus && genus != a->genus) continue;
@@ -258,8 +258,8 @@ void caosVM::c_ESEE() {
 	caosVar nullv; nullv.reset();
 	valueStack.push_back(nullv);
 
-	std::vector<boost::shared_ptr<Agent> > agents = getVisibleList(seeing, family, genus, species);
-	for (std::vector<boost::shared_ptr<Agent> >::iterator i = agents.begin(); i != agents.end(); i++) {
+	std::vector<std::shared_ptr<Agent> > agents = getVisibleList(seeing, family, genus, species);
+	for (std::vector<std::shared_ptr<Agent> >::iterator i = agents.begin(); i != agents.end(); i++) {
 		caosVar v; v.setAgent(*i);
 		valueStack.push_back(v);
 	}
@@ -286,9 +286,9 @@ void caosVM::c_ETCH() {
 	caosVar nullv; nullv.reset();
 	valueStack.push_back(nullv);
 	
-	for (std::list<boost::shared_ptr<Agent> >::iterator i
+	for (std::list<std::shared_ptr<Agent> >::iterator i
 			= world.agents.begin(); i != world.agents.end(); i++) {
-		boost::shared_ptr<Agent> a = (*i);
+		std::shared_ptr<Agent> a = (*i);
 		if (!a) continue;
 		if (species && species != a->species) continue;
 		if (genus && genus != a->genus) continue;
@@ -371,7 +371,7 @@ void caosVM::c_CALL() {
 	valid_agent(owner);
 	caos_assert(script_no >= 0 && script_no < 65536);
 
-	shared_ptr<script> s = owner->findScript(script_no);
+	std::shared_ptr<script> s = owner->findScript(script_no);
 	if (!s) return;
 	caosVM *newvm = world.getVM(owner);
 	newvm->trace = trace;

--- a/src/caos/caosVM_genetics.cpp
+++ b/src/caos/caosVM_genetics.cpp
@@ -82,7 +82,7 @@ void caosVM::c_GENE_LOAD() {
 	VM_PARAM_INTEGER(slot)
 	VM_PARAM_VALIDAGENT(agent)
 
-	shared_ptr<genomeFile> p = world.loadGenome(genefile);
+	std::shared_ptr<genomeFile> p = world.loadGenome(genefile);
 	if (!p)
 		throw creaturesException("failed to find genome file '" + genefile + "'");
 	
@@ -104,7 +104,7 @@ void caosVM::c_GENE_MOVE() {
 	VM_PARAM_INTEGER(dest_slot)
 	VM_PARAM_VALIDAGENT(dest_agent)
 
-	std::map<unsigned int, shared_ptr<class genomeFile> >::iterator i = src_agent->genome_slots.find(src_slot);
+	std::map<unsigned int, std::shared_ptr<class genomeFile> >::iterator i = src_agent->genome_slots.find(src_slot);
 	caos_assert(i != src_agent->genome_slots.end());
 
 	std::string moniker = world.history.findMoniker(i->second);
@@ -128,7 +128,7 @@ void caosVM::v_GTOS() {
 	if (targ->genome_slots.find(slot) == targ->genome_slots.end()) {
 		result.setString(""); // CV needs this, at least
 	} else {
-		shared_ptr<class genomeFile> g = targ->genome_slots[slot];
+		std::shared_ptr<class genomeFile> g = targ->genome_slots[slot];
 		result.setString(world.history.findMoniker(g));
 	}
 }

--- a/src/caos/caosVM_map.cpp
+++ b/src/caos/caosVM_map.cpp
@@ -32,7 +32,7 @@ using std::cerr;
 
 #define CAOS_LVALUE_TARG_ROOM(name, check, get, set) \
 	CAOS_LVALUE_TARG(name, \
-			shared_ptr<Room> r = roomContainingAgent(targ); \
+			std::shared_ptr<Room> r = roomContainingAgent(targ); \
 			caos_assert(r); \
 			check, \
 			get, \
@@ -180,7 +180,7 @@ void caosVM::v_ADDR() {
 	VM_PARAM_INTEGER(x_left)
 	VM_PARAM_INTEGER(metaroomid)
 
-	shared_ptr<Room> r(new Room(x_left, x_right,
+	std::shared_ptr<Room> r(new Room(x_left, x_right,
 			y_left_ceiling, y_right_ceiling,
 			y_left_floor, y_right_floor));
 	MetaRoom *m = world.map.getMetaRoom(metaroomid);
@@ -201,7 +201,7 @@ void caosVM::c_RTYP() {
 	VM_PARAM_INTEGER(roomtype)
 	VM_PARAM_INTEGER(roomid)
 
-	shared_ptr<Room> room = world.map.getRoom(roomid);
+	std::shared_ptr<Room> room = world.map.getRoom(roomid);
 	caos_assert(room);
 	room->type = roomtype;
 }
@@ -216,7 +216,7 @@ void caosVM::v_RTYP() {
 	VM_VERIFY_SIZE(1)
 	VM_PARAM_INTEGER(roomid)
 
-	shared_ptr<Room> room = world.map.getRoom(roomid);
+	std::shared_ptr<Room> room = world.map.getRoom(roomid);
 	if (room)
 		result.setInt(room->type.getInt());
 	else
@@ -233,7 +233,7 @@ void caosVM::v_RTYP() {
 */
 void caosVM::v_RTYP_c2() {
 	valid_agent(targ);
-	shared_ptr<Room> r = world.map.roomAt(targ->x + (targ->getWidth() / 2.0f), targ->y + (targ->getHeight() / 2.0f));
+	std::shared_ptr<Room> r = world.map.roomAt(targ->x + (targ->getWidth() / 2.0f), targ->y + (targ->getHeight() / 2.0f));
 	if (!r) result.setInt(-1);
 	else {
 		result.setInt(r->type.getInt());
@@ -254,7 +254,7 @@ void caosVM::c_SETV_RTYP() {
 	// TODO: this does actually work on targ, right?
 	// seems to work for the airlock, anyway  -nornagon
 	valid_agent(targ);
-	shared_ptr<Room> r = world.map.roomAt(targ->x + (targ->getWidth() / 2.0f), targ->y + (targ->getHeight() / 2.0f));
+	std::shared_ptr<Room> r = world.map.roomAt(targ->x + (targ->getWidth() / 2.0f), targ->y + (targ->getHeight() / 2.0f));
 	if (!r) return; // TODO: correct behaviour?
 	else
 		r->type.setInt(roomtype);
@@ -272,8 +272,8 @@ void caosVM::c_DOOR() {
 	VM_PARAM_INTEGER(room2)
 	VM_PARAM_INTEGER(room1)
 
-	shared_ptr<Room> r1 = world.map.getRoom(room1);
-	shared_ptr<Room> r2 = world.map.getRoom(room2);
+	std::shared_ptr<Room> r1 = world.map.getRoom(room1);
+	std::shared_ptr<Room> r2 = world.map.getRoom(room2);
 	caos_assert(r1); caos_assert(r2);
 	if (r1->doors.find(r2) == r1->doors.end()) {
 		RoomDoor *door = new RoomDoor;
@@ -332,7 +332,7 @@ void caosVM::v_ROOM() {
 	VM_VERIFY_SIZE(1)
 	VM_PARAM_VALIDAGENT(agent)
 	
-	shared_ptr<Room> r = roomContainingAgent(agent);
+	std::shared_ptr<Room> r = roomContainingAgent(agent);
 	if (r)
 		result.setInt(r->id);
 	else
@@ -407,7 +407,7 @@ void caosVM::c_PROP() {
 		caos_assert(0.0f <= cavalue);
 	caos_assert(0 <= caindex && caindex <= 19);
 
-	shared_ptr<Room> room = world.map.getRoom(roomid);
+	std::shared_ptr<Room> room = world.map.getRoom(roomid);
 	caos_assert(room);
 	room->ca[caindex] = cavalue;
 }
@@ -430,7 +430,7 @@ void caosVM::v_PROP() {
 		return;
 	}
 	
-	shared_ptr<Room> room = world.map.getRoom(roomid);
+	std::shared_ptr<Room> room = world.map.getRoom(roomid);
 	caos_assert(room);
 		result.setFloat(room->ca[caindex]);
 }
@@ -477,7 +477,7 @@ void caosVM::v_GRAP() {
 	VM_PARAM_FLOAT(y)
 	VM_PARAM_FLOAT(x)
 
-	shared_ptr<Room> room = world.map.roomAt(x, y);
+	std::shared_ptr<Room> room = world.map.roomAt(x, y);
 	if (room) {
 		result.setInt(room->id);
 	} else {
@@ -516,8 +516,8 @@ void caosVM::c_LINK() {
 	VM_PARAM_INTEGER(room2)
 	VM_PARAM_INTEGER(room1)
 
-	shared_ptr<Room> one = world.map.getRoom(room1);
-	shared_ptr<Room> two = world.map.getRoom(room2);
+	std::shared_ptr<Room> one = world.map.getRoom(room1);
+	std::shared_ptr<Room> two = world.map.getRoom(room2);
 	caos_assert(one && two);
 
 	// TODO
@@ -533,8 +533,8 @@ void caosVM::v_LINK() {
 	VM_PARAM_INTEGER(room2)
 	VM_PARAM_INTEGER(room1)
 
-	shared_ptr<Room> one = world.map.getRoom(room1);
-	shared_ptr<Room> two = world.map.getRoom(room2);
+	std::shared_ptr<Room> one = world.map.getRoom(room1);
+	std::shared_ptr<Room> two = world.map.getRoom(room2);
 	caos_assert(one && two);
 
 	result.setInt(0); // TODO
@@ -567,7 +567,7 @@ void caosVM::v_GRID() {
 			dest.y += targ->range.getFloat(); break;
 	}
 	
-	shared_ptr<Room> ourRoom = world.map.roomAt(src.x, src.y);
+	std::shared_ptr<Room> ourRoom = world.map.roomAt(src.x, src.y);
 	if (!ourRoom) {
 		// (should we REALLY check for it being in the room system, here?)
 		cerr << agent->identify() << " tried using GRID but isn't in the room system!\n";
@@ -575,7 +575,7 @@ void caosVM::v_GRID() {
 		return;
 	}
 
-	unsigned int dummy1; Line dummy2; Point point; shared_ptr<Room> room;
+	unsigned int dummy1; Line dummy2; Point point; std::shared_ptr<Room> room;
 	bool collided = world.map.collideLineWithRoomBoundaries(src, dest, ourRoom, room, point, dummy2, dummy1, targ->perm);
 
 	if (!room) result.setInt(-1);
@@ -629,7 +629,7 @@ void caosVM::c_ALTR() {
 	
 	caos_assert(0 <= caindex && caindex <= 19);
 
-	shared_ptr<Room> room;
+	std::shared_ptr<Room> room;
 	if (roomid == -1) {
 		valid_agent(targ);
 		room = world.map.roomAt(targ->x + (targ->getWidth() / 2.0f), targ->y + (targ->getHeight() / 2.0f));
@@ -652,7 +652,7 @@ void caosVM::c_ALTR() {
 void caosVM::v_RLOC() {
 	VM_PARAM_INTEGER(roomid)
 
-	shared_ptr<Room> r = world.map.getRoom(roomid);
+	std::shared_ptr<Room> r = world.map.getRoom(roomid);
 	caos_assert(r);
 
 	result.setString(boost::str(boost::format("%d %d %d %d %d %d") % r->x_left % r->x_right % r->y_left_ceiling % r->y_right_ceiling % r->y_left_floor % r->y_right_floor));
@@ -709,7 +709,7 @@ void caosVM::v_ERID() {
 		// TODO
 	} else {
 		MetaRoom *r = world.map.getMetaRoom(metaroom_id);
-		for (std::vector<shared_ptr<Room> >::iterator i = r->rooms.begin(); i != r->rooms.end(); i++) {
+		for (std::vector<std::shared_ptr<Room> >::iterator i = r->rooms.begin(); i != r->rooms.end(); i++) {
 			if (out.size() > 0) out = out + " ";
 			out = out + boost::str(boost::format("%d") % (*i)->id);
 		}
@@ -728,7 +728,7 @@ void caosVM::v_ERID() {
 void caosVM::c_DELR() {
 	VM_PARAM_INTEGER(room_id)
 
-	shared_ptr<Room> r = world.map.getRoom(room_id);
+	std::shared_ptr<Room> r = world.map.getRoom(room_id);
 	caos_assert(r);
 
 	// TODO
@@ -758,7 +758,7 @@ void caosVM::v_HIRP() {
 	VM_PARAM_INTEGER(caindex) caos_assert(0 <= caindex && caindex <= 19);
 	VM_PARAM_INTEGER(roomid)
 	
-	shared_ptr<Room> r = world.map.getRoom(roomid);
+	std::shared_ptr<Room> r = world.map.getRoom(roomid);
 	caos_assert(r);
 
 	result.setInt(roomid); // TODO
@@ -773,7 +773,7 @@ void caosVM::v_LORP() {
 	VM_PARAM_INTEGER(caindex) caos_assert(0 <= caindex && caindex <= 19);
 	VM_PARAM_INTEGER(roomid)
 	
-	shared_ptr<Room> r = world.map.getRoom(roomid);
+	std::shared_ptr<Room> r = world.map.getRoom(roomid);
 	caos_assert(r);
 
 	result.setInt(roomid); // TODO
@@ -786,7 +786,7 @@ void caosVM::v_LORP() {
 void caosVM::v_TORX() {
 	VM_PARAM_INTEGER(roomid)
 
-	shared_ptr<Room> r = world.map.getRoom(roomid);
+	std::shared_ptr<Room> r = world.map.getRoom(roomid);
 	caos_assert(r);
 	valid_agent(targ);
 
@@ -801,7 +801,7 @@ void caosVM::v_TORX() {
 void caosVM::v_TORY() {
 	VM_PARAM_INTEGER(roomid)
 
-	shared_ptr<Room> r = world.map.getRoom(roomid);
+	std::shared_ptr<Room> r = world.map.getRoom(roomid);
 	caos_assert(r);
 	valid_agent(targ);
 
@@ -919,7 +919,7 @@ CAOS_LVALUE_ROOM_SIMPLE(PSRC, r->psrc)
 */
 void caosVM::v_WNDX() {
 	valid_agent(targ);
-	shared_ptr<Room> r = roomContainingAgent(targ);
+	std::shared_ptr<Room> r = roomContainingAgent(targ);
 	caos_assert(r);
 	result.setInt(r->windx);
 }
@@ -931,7 +931,7 @@ void caosVM::v_WNDX() {
 */
 void caosVM::v_WNDY() {
 	valid_agent(targ);
-	shared_ptr<Room> r = roomContainingAgent(targ);
+	std::shared_ptr<Room> r = roomContainingAgent(targ);
 	caos_assert(r);
 	result.setInt(r->windy);
 }
@@ -960,8 +960,8 @@ void caosVM::c_SETV_DOOR() {
 	// TODO: what's direction for?
 
 	// code identical to c2e DOOR
-	shared_ptr<Room> r1 = world.map.getRoom(room1);
-	shared_ptr<Room> r2 = world.map.getRoom(room2);
+	std::shared_ptr<Room> r1 = world.map.getRoom(room1);
+	std::shared_ptr<Room> r2 = world.map.getRoom(room2);
 	caos_assert(r1); caos_assert(r2);
 	if (r1->doors.find(r2) == r1->doors.end()) {
 		RoomDoor *door = new RoomDoor;
@@ -986,7 +986,7 @@ void caosVM::c_SETV_DOOR() {
 void caosVM::v_FLOR() {
 	valid_agent(targ);
 
-	shared_ptr<Room> r = roomContainingAgent(targ);
+	std::shared_ptr<Room> r = roomContainingAgent(targ);
 	if (!r)
 		result.setInt(0); // TODO
 	else
@@ -1034,9 +1034,9 @@ void caosVM::c_ROOM() {
 	VM_PARAM_INTEGER(left)
 	VM_PARAM_INTEGER(roomno)
 
-	shared_ptr<Room> r = world.map.getRoom(roomno);
+	std::shared_ptr<Room> r = world.map.getRoom(roomno);
 	if (!r) {
-		shared_ptr<Room> r2(new Room(left, right, top, top, bottom, bottom));
+		std::shared_ptr<Room> r2(new Room(left, right, top, top, bottom, bottom));
 		r = r2;
 
 		MetaRoom *m = world.map.getMetaRoom(0);
@@ -1079,9 +1079,9 @@ void caosVM::c_ROOM_c2() {
 	VM_PARAM_INTEGER(left)
 	VM_PARAM_INTEGER(roomno)
 	
-	shared_ptr<Room> r = world.map.getRoom(roomno);
+	std::shared_ptr<Room> r = world.map.getRoom(roomno);
 	if (!r) {
-		r = shared_ptr<Room>(new Room(left, right, top, top, bottom, bottom));
+		r = std::shared_ptr<Room>(new Room(left, right, top, top, bottom, bottom));
 		MetaRoom *m = world.map.getMetaRoom(0);
 		unsigned int roomid = m->addRoom(r);
 		r->id = roomno;
@@ -1129,7 +1129,7 @@ void caosVM::v_ROOM_c1() {
 	VM_PARAM_INTEGER(data) caos_assert(data >= 0 && data <= (engine.version == 1 ? 4 : 19));
 	VM_PARAM_INTEGER(roomno)
 
-	shared_ptr<Room> r = world.map.getRoom(roomno);
+	std::shared_ptr<Room> r = world.map.getRoom(roomno);
 	if (!r) {
 		result.setInt(0);
 		return;
@@ -1251,7 +1251,7 @@ void caosVM::c_SSFC() {
 
 	caos_assert(coordcount >= 0); // this should never happen unless the parser breaks or we load a bad savefile
 
-	shared_ptr<Room> r = world.map.getRoom(roomno);
+	std::shared_ptr<Room> r = world.map.getRoom(roomno);
 	caos_assert(r);
 
 	r->floorpoints.clear();

--- a/src/caos/caosVM_motion.cpp
+++ b/src/caos/caosVM_motion.cpp
@@ -164,7 +164,7 @@ void caosVM::v_OBST() {
 			dest.y += targ->range.getFloat(); break;
 	}
 
-	shared_ptr<Room> ourRoom = world.map.roomAt(src.x, src.y);
+	std::shared_ptr<Room> ourRoom = world.map.roomAt(src.x, src.y);
 	if (!ourRoom) {
 		// TODO: is this correct behaviour?
 		result.setFloat(0.0f);

--- a/src/caos/caosVM_ports.cpp
+++ b/src/caos/caosVM_ports.cpp
@@ -88,7 +88,7 @@ void caosVM::c_PRT_INEW() {
 
 	valid_agent(targ);
 	caos_assert(targ->inports.find(id) == targ->inports.end()); // TODO: multiple PRT: INEWs with the same id allowed?
-	targ->inports[id] = boost::shared_ptr<InputPort>(new InputPort(x, y, name, desc, msgnum));
+	targ->inports[id] = std::shared_ptr<InputPort>(new InputPort(x, y, name, desc, msgnum));
 }
 
 /**
@@ -225,7 +225,7 @@ void caosVM::c_PRT_ONEW() {
 
 	valid_agent(targ);
 	caos_assert(targ->outports.find(id) == targ->outports.end());
-	targ->outports[id] = boost::shared_ptr<OutputPort>(new OutputPort(x, y, name, desc));
+	targ->outports[id] = std::shared_ptr<OutputPort>(new OutputPort(x, y, name, desc));
 }
 
 /**

--- a/src/caos/caosVM_scripts.cpp
+++ b/src/caos/caosVM_scripts.cpp
@@ -246,7 +246,7 @@ void caosVM::v_SORQ() {
 	VM_PARAM_INTEGER(genus) caos_assert(event >= 0 && event <= 255);
 	VM_PARAM_INTEGER(family) caos_assert(event >= 0 && event <= 255);
 
-	shared_ptr<script> s = world.scriptorium.getScript(family, genus, species, event);
+	std::shared_ptr<script> s = world.scriptorium.getScript(family, genus, species, event);
 	if (s) result.setInt(1);
 	else result.setInt(0);
 }

--- a/src/caos/caosVM_sounds.cpp
+++ b/src/caos/caosVM_sounds.cpp
@@ -161,7 +161,7 @@ void caosVM::c_RMSC() {
 	VM_PARAM_INTEGER(y)
 	VM_PARAM_INTEGER(x)
 
-	shared_ptr<Room> r = world.map.roomAt(x, y);
+	std::shared_ptr<Room> r = world.map.roomAt(x, y);
 	caos_assert(r);
 
 	r->music = track_name;
@@ -178,7 +178,7 @@ void caosVM::v_RMSC() {
 	VM_PARAM_INTEGER(y)
 	VM_PARAM_INTEGER(x)
 
-	shared_ptr<Room> r = world.map.roomAt(x, y);
+	std::shared_ptr<Room> r = world.map.roomAt(x, y);
 	caos_assert(r);
 
 	result.setString(r->music);
@@ -386,7 +386,7 @@ void caosVM::c_DBG_SINE() {
 		if (targ->sound)
 			targ->sound->stop();
 	}
-	boost::shared_ptr<AudioSource> src;
+	std::shared_ptr<AudioSource> src;
 	if (track == 2)
 		src = engine.audio->getBGMSource();
 	else
@@ -408,7 +408,7 @@ void caosVM::c_DBG_SINE() {
  Don't touch.
  */
 void caosVM::c_DBG_SBGM() {
-	boost::shared_ptr<AudioSource> src = engine.audio->getBGMSource();
+	std::shared_ptr<AudioSource> src = engine.audio->getBGMSource();
 	if (src)
 		src->stop();
 }

--- a/src/caos/caosVM_variables.cpp
+++ b/src/caos/caosVM_variables.cpp
@@ -188,7 +188,7 @@ void caosVM::v_TYPE() {
 	else if (value.hasString())
 		result.setInt(2);
 	else if (value.hasAgent()) {
-		boost::shared_ptr<Agent> a = value.getAgent();
+		std::shared_ptr<Agent> a = value.getAgent();
 		if (a == 0)
 			result.setInt(-1);
 		else if (typeid(*a) == typeid(SimpleAgent))

--- a/src/caos/caosVM_vehicles.cpp
+++ b/src/caos/caosVM_vehicles.cpp
@@ -100,8 +100,8 @@ void caosVM::c_GPAS() {
 	// TODO: see other GPAS below
 	// TODO: are we sure c2e grabs passengers by agent rect?
 	// TODO: do we need to check greedycabin attr for anything?
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
-		boost::shared_ptr<Agent> a = (*i);
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+		std::shared_ptr<Agent> a = (*i);
 		if (!a) continue;
 		if (a.get() == v) continue;
 		if (family && family != a->family) continue;
@@ -127,8 +127,8 @@ void caosVM::c_GPAS_c2() {
 
 	// TODO: are we sure c1/c2 grab passengers by agent rect?
 	// TODO: do we need to check greedycabin attr for anything?
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
-		boost::shared_ptr<Agent> a = (*i);
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+		std::shared_ptr<Agent> a = (*i);
 		if (!a) continue;
 		if (a.get() == v) continue;
 		if (a->family != 4) continue; // only pickup creatures (TODO: good check?)

--- a/src/caosScript.h
+++ b/src/caosScript.h
@@ -79,7 +79,7 @@ struct script {
 		std::vector<bytestring_t> bytestrs;
 		// a normalized copy of the script source. this is used for error tracing
 		shared_str code;
-		shared_ptr<std::vector<toktrace> > tokinfo;
+		std::shared_ptr<std::vector<toktrace> > tokinfo;
 	public:
 		int fmly, gnus, spcs, scrp;
 		const class Dialect *dialect;
@@ -185,7 +185,7 @@ class CAOSExpression;
 
 struct CAOSCmd {
 	const cmdinfo *op;
-	std::vector<boost::shared_ptr<CAOSExpression> > arguments;
+	std::vector<std::shared_ptr<CAOSExpression> > arguments;
 	int traceidx;
 	CAOSCmd() { op = 0; traceidx = -1; }
 	CAOSCmd(const CAOSCmd &c) : op(c.op), arguments(c.arguments) { }
@@ -241,9 +241,9 @@ class caosScript { //: Collectable {
 public:
 	const Dialect *d;
 	std::string filename;
-	shared_ptr<script> installer, removal;
-	std::vector<shared_ptr<script> > scripts;
-	shared_ptr<script> current;
+	std::shared_ptr<script> installer, removal;
+	std::vector<std::shared_ptr<script> > scripts;
+	std::shared_ptr<script> current;
 
 	caosScript(const std::string &dialect, const std::string &fn);
 	caosScript() { d = NULL; }
@@ -257,12 +257,12 @@ protected:
 	void emitOp(opcode_t op, int argument);
 	void emitCmd(const char *name);
 	void emitConst(const caosVar &);
-	boost::shared_ptr<CAOSExpression> readExpr(const enum ci_type xtype);
-	void emitExpr(boost::shared_ptr<CAOSExpression> ce);
+	std::shared_ptr<CAOSExpression> readExpr(const enum ci_type xtype);
+	void emitExpr(std::shared_ptr<CAOSExpression> ce);
 	const cmdinfo *readCommand(class token *t, const std::string &prefix, bool except = true);
 	void parseloop(int state, void *info);
 
-	shared_ptr<std::vector<token> > tokens;
+	std::shared_ptr<std::vector<token> > tokens;
 	int curindex; // index to the next token to be read
    	int errindex; // index to the token to report parse errors on
 	int traceindex; // index to the token to report runtime errors on

--- a/src/caosVM.cpp
+++ b/src/caosVM.cpp
@@ -303,7 +303,7 @@ inline void caosVM::runOp() {
 	runops++;
 	if (runops > 1000000) throw creaturesException("script exceeded 1m ops");
 
-	shared_ptr<script> scr = currentscript;
+	std::shared_ptr<script> scr = currentscript;
 	caosOp op = currentscript->getOp(cip);
 	
 	try {
@@ -333,7 +333,7 @@ void caosVM::stop() {
 	var.reduce(0);
 }
 
-void caosVM::runEntirely(shared_ptr<script> s) {
+void caosVM::runEntirely(std::shared_ptr<script> s) {
 	// caller is responsible for resetting/setting *all* state!
 	cip = nip = runops = 0;
 	currentscript = s;
@@ -350,7 +350,7 @@ void caosVM::runEntirely(shared_ptr<script> s) {
 	}
 }
 
-bool caosVM::fireScript(shared_ptr<script> s, bool nointerrupt, Agent *frm) {
+bool caosVM::fireScript(std::shared_ptr<script> s, bool nointerrupt, Agent *frm) {
 	assert(owner);
 	assert(s);
 	if (lock) return false; // can't interrupt scripts which called LOCK

--- a/src/caosVM.h
+++ b/src/caosVM.h
@@ -30,8 +30,8 @@
 #include "lazy_array.h"
 
 #include <boost/variant.hpp>
-#include <boost/weak_ptr.hpp>
-using boost::weak_ptr;
+#include <memory>
+using std::weak_ptr;
 
 class script;
 
@@ -176,7 +176,7 @@ public:
 	const caosVM_p vm; // == this
 	
 	// script state...
-	shared_ptr<script> currentscript;
+	std::shared_ptr<script> currentscript;
 	int nip, cip, runops;
 	
 	bool inst, lock, stop_loop;
@@ -1100,11 +1100,11 @@ public:
 	void invoke_cmd(script *s, bool is_saver, int opidx);
 	void runOpCore(script *s, struct caosOp op);
 	void runOp();
-	void runEntirely(shared_ptr<script> s);
+	void runEntirely(std::shared_ptr<script> s);
 
 	void tick();
 	void stop();
-	bool fireScript(shared_ptr<script> s, bool nointerrupt, Agent *frm = 0);
+	bool fireScript(std::shared_ptr<script> s, bool nointerrupt, Agent *frm = 0);
 
 	caosVM(const AgentRef &o);
 	~caosVM();
@@ -1160,7 +1160,7 @@ class caosVM__lval {
 	name = __x.getRVal().getFloat(); } vm->valueStack.pop_back();
 #define VM_PARAM_VECTOR(name) Vector<float> name; { VM_STACK_CHECK(vm); vmStackItem __x = vm->valueStack.back(); \
 	name = __x.getRVal().getVector(); } vm->valueStack.pop_back();
-#define VM_PARAM_AGENT(name) boost::shared_ptr<Agent> name; { VM_STACK_CHECK(vm); vmStackItem __x = vm->valueStack.back(); \
+#define VM_PARAM_AGENT(name) std::shared_ptr<Agent> name; { VM_STACK_CHECK(vm); vmStackItem __x = vm->valueStack.back(); \
 	name = __x.getRVal().getAgent(); } vm->valueStack.pop_back();
 // TODO: is usage of valid_agent correct here, or should we be caos_asserting?
 #define VM_PARAM_VALIDAGENT(name) VM_PARAM_AGENT(name) valid_agent(name);

--- a/src/caosVar.h
+++ b/src/caosVar.h
@@ -203,7 +203,7 @@ class caosVar {
 			return boost::apply_visitor(stringVisit(), value);
 		}
 
-		boost::shared_ptr<Agent> getAgent() const {
+		std::shared_ptr<Agent> getAgent() const {
 			return getAgentRef().lock();
 		}
 

--- a/src/creatures/Biochemistry.cpp
+++ b/src/creatures/Biochemistry.cpp
@@ -23,7 +23,7 @@
 #include "c2eBrain.h"
 #include "oldBrain.h"
 
-using boost::shared_ptr;
+using std::shared_ptr;
 
 void oldCreature::addChemical(unsigned char id, unsigned char val) {
 	if (id == 0) return;
@@ -85,7 +85,7 @@ void c1Creature::tickBiochemistry() {
 	}
 
 	// process reactions
-	for (std::vector<shared_ptr<c1Reaction> >::iterator i = reactions.begin(); i != reactions.end(); i++) {
+	for (std::vector<std::shared_ptr<c1Reaction> >::iterator i = reactions.begin(); i != reactions.end(); i++) {
 		processReaction(**i);
 	}
 
@@ -98,7 +98,7 @@ void c2Creature::tickBiochemistry() {
 	if ((ticks % 2) != 0) return; // every 2 ticks (0.2s)
 
 	// tick organs
-	for (std::vector<shared_ptr<c2Organ> >::iterator x = organs.begin(); x != organs.end(); x++) {
+	for (std::vector<std::shared_ptr<c2Organ> >::iterator x = organs.begin(); x != organs.end(); x++) {
 		(*x)->tick();
 	}
 
@@ -131,7 +131,7 @@ void c2eCreature::tickBiochemistry() {
 	if ((ticks % 4) != 0) return;
 	
 	// tick organs
-	for (std::vector<shared_ptr<c2eOrgan> >::iterator x = organs.begin(); x != organs.end(); x++) {
+	for (std::vector<std::shared_ptr<c2eOrgan> >::iterator x = organs.begin(); x != organs.end(); x++) {
 		(*x)->tick();
 	}
 
@@ -443,7 +443,7 @@ void c2Organ::processGenes() {
 		if (!parent->shouldProcessGene(*i)) continue;
 
 		if (typeid(*(*i)) == typeid(bioReactionGene)) {
-			reactions.push_back(shared_ptr<c2Reaction>(new c2Reaction()));
+			reactions.push_back(std::shared_ptr<c2Reaction>(new c2Reaction()));
 			reactions.back()->init((bioReactionGene *)(*i));
 		} else if (typeid(*(*i)) == typeid(bioEmitterGene)) {
 			emitters.push_back(c2Emitter());
@@ -456,14 +456,14 @@ void c2Organ::processGenes() {
 }
 
 void c2eOrgan::processGenes() {
-	shared_ptr<c2eReaction> r; // we need to store the previous reaction for possible receptor use
+	std::shared_ptr<c2eReaction> r; // we need to store the previous reaction for possible receptor use
 	// TODO: should this cope with receptors created at other lifestages? i doubt it.. - fuzzie
 
 	for (vector<gene *>::iterator i = ourGene->genes.begin(); i != ourGene->genes.end(); i++) {
 		if (!parent->shouldProcessGene(*i)) continue;
 
 		if (typeid(*(*i)) == typeid(bioReactionGene)) {
-			reactions.push_back(shared_ptr<c2eReaction>(new c2eReaction()));
+			reactions.push_back(std::shared_ptr<c2eReaction>(new c2eReaction()));
 			r = reactions.back();
 			reactions.back()->init((bioReactionGene *)(*i));
 		} else if (typeid(*(*i)) == typeid(bioEmitterGene)) {
@@ -513,7 +513,7 @@ void c2Organ::tick() {
 				processEmitter(*i);
 			
 			// *** tick reactions
-			for (vector<shared_ptr<c2Reaction> >::iterator i = reactions.begin(); i != reactions.end(); i++)
+			for (vector<std::shared_ptr<c2Reaction> >::iterator i = reactions.begin(); i != reactions.end(); i++)
 				processReaction(**i);
 		} else {
 			// not enough energy!
@@ -579,7 +579,7 @@ void c2eOrgan::tick() {
 				processEmitter(*i);
 			
 			// *** tick reactions
-			for (vector<shared_ptr<c2eReaction> >::iterator i = reactions.begin(); i != reactions.end(); i++)
+			for (vector<std::shared_ptr<c2eReaction> >::iterator i = reactions.begin(); i != reactions.end(); i++)
 				processReaction(**i);
 		} else {
 			// *** out of energy damage	
@@ -602,13 +602,13 @@ void c2eOrgan::tick() {
 	}
 	
 	// *** tick receptors	
-	for (vector<shared_ptr<c2eReaction> >::iterator i = reactions.begin(); i != reactions.end(); i++) (*i)->receptors = 0;
+	for (vector<std::shared_ptr<c2eReaction> >::iterator i = reactions.begin(); i != reactions.end(); i++) (*i)->receptors = 0;
 	clockratereceptors = 0; repairratereceptors = 0; injuryreceptors = 0;
 		
 	for (vector<c2eReceptor>::iterator i = receptors.begin(); i != receptors.end(); i++)
 		processReceptor(*i, ticked);
 	
-	for (vector<shared_ptr<c2eReaction> >::iterator i = reactions.begin(); i != reactions.end(); i++) if ((*i)->receptors > 0) (*i)->rate /= (*i)->receptors;
+	for (vector<std::shared_ptr<c2eReaction> >::iterator i = reactions.begin(); i != reactions.end(); i++) if ((*i)->receptors > 0) (*i)->rate /= (*i)->receptors;
 	if (clockratereceptors > 0) clockrate /= clockratereceptors;
 	if (repairratereceptors > 0) repairrate /= repairratereceptors;
 	if (injuryreceptors > 0) injurytoapply /= injuryreceptors;
@@ -971,7 +971,7 @@ float *c2eOrgan::getLocusPointer(bool receptor, unsigned char o, unsigned char t
 			break;
 		case 3: // reaction
 			if (t == 0 && l == 0) { // reaction rate
-				shared_ptr<c2eReaction> r = reactions.back();
+				std::shared_ptr<c2eReaction> r = reactions.back();
 				if (!r) {
 					std::cout << "c2eOrgan::getLocusPointer failed to find a reaction" << std::endl;
 					return 0;
@@ -1012,7 +1012,7 @@ void c2Receptor::init(bioReceptorGene *g, c2Organ *parent) {
 	locus = parent->getLocusPointer(true, g->organ, g->tissue, g->locus, &receptors);
 }
 	
-void c2eReceptor::init(bioReceptorGene *g, c2eOrgan *parent, shared_ptr<c2eReaction> r) {
+void c2eReceptor::init(bioReceptorGene *g, c2eOrgan *parent, std::shared_ptr<c2eReaction> r) {
 	data = g;
 	processed = false;
 	nominal = g->nominal / 255.0f;

--- a/src/creatures/Creature.cpp
+++ b/src/creatures/Creature.cpp
@@ -26,7 +26,7 @@
 #include "c2eBrain.h"
 #include "oldBrain.h"
 
-Creature::Creature(shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a) {
+Creature::Creature(std::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a) {
 	assert(g);
 	genome = g;
 
@@ -93,7 +93,7 @@ void oldCreature::processGenes() {
 void c2Creature::processGenes() {
 	oldCreature::processGenes();
 
-	for (std::vector<shared_ptr<c2Organ> >::iterator x = organs.begin(); x != organs.end(); x++) {
+	for (std::vector<std::shared_ptr<c2Organ> >::iterator x = organs.begin(); x != organs.end(); x++) {
 		(*x)->processGenes();
 	}
 }
@@ -104,7 +104,7 @@ void c2eCreature::processGenes() {
 
 	brain->processGenes();
 	Creature::processGenes();
-	for (std::vector<shared_ptr<c2eOrgan> >::iterator x = organs.begin(); x != organs.end(); x++) {
+	for (std::vector<std::shared_ptr<c2eOrgan> >::iterator x = organs.begin(); x != organs.end(); x++) {
 		(*x)->processGenes();
 	}
 }
@@ -197,7 +197,7 @@ void Creature::tick() {
 /*
  * oldCreature contains the shared elements of C1 of C2 (creatures are mostly identical in both games)
  */
-oldCreature::oldCreature(shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a) : Creature(g, is_female, _variant, a) {
+oldCreature::oldCreature(std::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a) : Creature(g, is_female, _variant, a) {
 	biochemticks = 0;
 	halflives = 0;
 	
@@ -215,7 +215,7 @@ oldCreature::oldCreature(shared_ptr<genomeFile> g, bool is_female, unsigned char
 	brain = 0; // just in case
 }
 
-c1Creature::c1Creature(shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a) : oldCreature(g, is_female, _variant, a) {
+c1Creature::c1Creature(std::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a) : oldCreature(g, is_female, _variant, a) {
 	assert(g->getVersion() == 1);
 
 	for (unsigned int i = 0; i < 6; i++) senses[i] = 0;
@@ -229,7 +229,7 @@ c1Creature::c1Creature(shared_ptr<genomeFile> g, bool is_female, unsigned char _
 	brain->init();
 }
 
-c2Creature::c2Creature(shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a) : oldCreature(g, is_female, _variant, a) {
+c2Creature::c2Creature(std::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a) : oldCreature(g, is_female, _variant, a) {
 	assert(g->getVersion() == 2);
 
 	for (unsigned int i = 0; i < 14; i++) senses[i] = 0;
@@ -245,7 +245,7 @@ c2Creature::c2Creature(shared_ptr<genomeFile> g, bool is_female, unsigned char _
 	brain->init();	
 }
 
-c2eCreature::c2eCreature(shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a) : Creature(g, is_female, _variant, a) {
+c2eCreature::c2eCreature(std::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a) : Creature(g, is_female, _variant, a) {
 	assert(g->getVersion() == 3);
 
 	for (unsigned int i = 0; i < 256; i++) chemicals[i] = 0.0f;
@@ -415,7 +415,7 @@ void c1Creature::addGene(gene *g) {
 	oldCreature::addGene(g);
 
 	if (typeid(*g) == typeid(bioReactionGene)) {
-		reactions.push_back(shared_ptr<c1Reaction>(new c1Reaction()));
+		reactions.push_back(std::shared_ptr<c1Reaction>(new c1Reaction()));
 		reactions.back()->init((bioReactionGene *)(g));
 	} else if (typeid(*g) == typeid(bioEmitterGene)) {
 		emitters.push_back(c1Emitter());
@@ -434,7 +434,7 @@ void c2Creature::addGene(gene *g) {
 		organGene *o = dynamic_cast<organGene *>(g);
 		assert(o);
 		if (!o->isBrain()) { // TODO: handle brain organ
-			organs.push_back(shared_ptr<c2Organ>(new c2Organ(this, o)));
+			organs.push_back(std::shared_ptr<c2Organ>(new c2Organ(this, o)));
 		}
 	}
 }
@@ -451,7 +451,7 @@ void c2eCreature::addGene(gene *g) {
 		organGene *o = dynamic_cast<organGene *>(g);
 		assert(o);
 		if (!o->isBrain()) { // TODO: handle brain organ
-			organs.push_back(shared_ptr<c2eOrgan>(new c2eOrgan(this, o)));
+			organs.push_back(std::shared_ptr<c2eOrgan>(new c2eOrgan(this, o)));
 		}
 	} else if (typeid(*g) == typeid(bioHalfLivesGene)) {
 		bioHalfLivesGene *d = dynamic_cast<bioHalfLivesGene *>(g);

--- a/src/creatures/Creature.h
+++ b/src/creatures/Creature.h
@@ -37,7 +37,7 @@ class Creature {
 protected:
 	CreatureAgent *parent;
 	Agent *parentagent;
-	boost::shared_ptr<genomeFile> genome;
+	std::shared_ptr<genomeFile> genome;
 	
 	// non-specific bits
 	unsigned short genus;
@@ -72,7 +72,7 @@ protected:
 	virtual void processGenes();
 	virtual void addGene(gene *);
 	
-	Creature(boost::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a);
+	Creature(std::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a);
 	void finishInit();
 
 public:
@@ -91,7 +91,7 @@ public:
 	void setZombie(bool z) { zombie = z; }
 	bool isZombie() { return zombie; }
 	unsigned int getAge() { return age; }
-	boost::shared_ptr<genomeFile> getGenome() { return genome; }
+	std::shared_ptr<genomeFile> getGenome() { return genome; }
 
 	unsigned short getGenus() { return genus; }
 	unsigned int getVariant() { return variant; }

--- a/src/creatures/CreatureAI.cpp
+++ b/src/creatures/CreatureAI.cpp
@@ -340,8 +340,8 @@ void Creature::chooseAgents() {
 
 	std::vector<std::vector<AgentRef> > possibles(chosenagents.size());
 
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
-		boost::shared_ptr<Agent> a = *i;
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+		std::shared_ptr<Agent> a = *i;
 		if (!a) continue;
 
 		// if agent category is -1 or outside of our #categories, continue

--- a/src/creatures/SkeletalCreature.cpp
+++ b/src/creatures/SkeletalCreature.cpp
@@ -128,7 +128,7 @@ std::string SkeletalCreature::dataString(unsigned int _stage, bool tryfemale, un
 }
 
 void SkeletalCreature::processGenes() {
-	shared_ptr<genomeFile> genome = creature->getGenome();
+	std::shared_ptr<genomeFile> genome = creature->getGenome();
 
 	for (vector<gene *>::iterator i = genome->genes.begin(); i != genome->genes.end(); i++) {
 		if (!creature->shouldProcessGene(*i)) continue;
@@ -244,12 +244,12 @@ void SkeletalCreature::skeletonInit() {
 	}
 }
 
-shared_ptr<creaturesImage> SkeletalCreature::tintBodySprite(shared_ptr<creaturesImage> s) {
+std::shared_ptr<creaturesImage> SkeletalCreature::tintBodySprite(std::shared_ptr<creaturesImage> s) {
 	// TODO: don't bother tinting if we don't need to
 	
 	// TODO: work out tinting for other engine versions
 	if (engine.version > 2) {
-		shared_ptr<creaturesImage> newimage = s->mutableCopy();
+		std::shared_ptr<creaturesImage> newimage = s->mutableCopy();
 		newimage->tint(creature->getTint(0), creature->getTint(1), creature->getTint(2), creature->getTint(3), creature->getTint(4));
 		return newimage;
 	}
@@ -393,7 +393,7 @@ void SkeletalCreature::snapDownFoot() {
 	MetaRoom *m = world.map.metaRoomAt(x, y);
 	if (!m) return; // TODO: exceptiony death
 
-	shared_ptr<Room> newroom;
+	std::shared_ptr<Room> newroom;
 
 	if (downfootroom) {
 		if (downfootroom->containsPoint(footx, footy)) {
@@ -404,7 +404,7 @@ void SkeletalCreature::snapDownFoot() {
 			} else {
 				float ydiff = 10000.0f; // TODO: big number
 				for (std::map<weak_ptr<Room>,RoomDoor *>::iterator i = downfootroom->doors.begin(); i != downfootroom->doors.end(); i++) {
-					shared_ptr<Room> thisroom = i->first.lock();
+					std::shared_ptr<Room> thisroom = i->first.lock();
 					if (engine.version == 2 && size.getInt() > i->second->perm) continue;
 					if (thisroom->x_left <= footx && thisroom->x_right >= footx) {
 						float thisydiff = fabs(footy - thisroom->floorYatX(footx));
@@ -417,7 +417,7 @@ void SkeletalCreature::snapDownFoot() {
 			}
 		}
 	} else {	
-		newroom = bestRoomAt(footx, footy, 3, m, shared_ptr<Room>());
+		newroom = bestRoomAt(footx, footy, 3, m, std::shared_ptr<Room>());
 
 		// insane emergency handling
 		float newfooty = footy;
@@ -438,7 +438,7 @@ void SkeletalCreature::snapDownFoot() {
 	if (!downfootroom /*|| !falling */) {
 		// TODO: hackery to cope with scripts moving us, this needs handling correctly somewhere
 		if (fabs(lastgoodfootx - attachmentX(orig_footpart, 1) - x) > 50.0f || fabs(lastgoodfooty - attachmentY(orig_footpart, 1) - y) > 50.0f) {
-			downfootroom = bestRoomAt(footx, footy, 3, m, shared_ptr<Room>());
+			downfootroom = bestRoomAt(footx, footy, 3, m, std::shared_ptr<Room>());
 			if (downfootroom) {
 				snapDownFoot();
 				return;
@@ -496,7 +496,7 @@ void SkeletalCreature::snapDownFoot() {
 			}
 		} else {
 			// TODO: hilar hack: same as above for perm
-			shared_ptr<Room> downroom = world.map.roomAt(footx, downfootroom->y_left_floor + 1);
+			std::shared_ptr<Room> downroom = world.map.roomAt(footx, downfootroom->y_left_floor + 1);
 			if (downfootroom->doors.find(downroom) != downfootroom->doors.end()) {
 				int permsize = (engine.version == 2 ? size.getInt() : perm);
 				if (permsize <= downfootroom->doors[downroom]->perm) {

--- a/src/creatures/SkeletalCreature.h
+++ b/src/creatures/SkeletalCreature.h
@@ -42,13 +42,13 @@ protected:
 	int oldfootx, oldfooty;
 	int lastgoodfootx, lastgoodfooty; // TODO: sucky code
 	bool downfoot_left;
-	shared_ptr<class Room> downfootroom;
+	std::shared_ptr<class Room> downfootroom;
 
 	creatureAppearanceGene *appearancegenes[6];
 	std::map<unsigned int, creaturePoseGene *> posegenes;
 	std::map<unsigned int, creatureGaitGene *> gaitgenes;
 
-	shared_ptr<creaturesImage> images[17];
+	std::shared_ptr<creaturesImage> images[17];
 	attFile att[17];
 
 	int width, height, adjustx, adjusty;
@@ -69,7 +69,7 @@ protected:
 	void processGenes();
 
 	creatureAppearanceGene *appearanceGeneForPart(char p);
-	shared_ptr<creaturesImage> tintBodySprite(shared_ptr<creaturesImage>);
+	std::shared_ptr<creaturesImage> tintBodySprite(std::shared_ptr<creaturesImage>);
 
 	Agent *getAgent() { return this; }
 

--- a/src/creatures/c2eBrain.h
+++ b/src/creatures/c2eBrain.h
@@ -21,11 +21,11 @@
 #define __C2EBRAIN_H
 
 #include "genome.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <set>
 #include <map>
 
-using boost::shared_ptr;
+using std::shared_ptr;
 
 class Creature;
 

--- a/src/creatures/c2eCreature.h
+++ b/src/creatures/c2eCreature.h
@@ -38,7 +38,7 @@ struct c2eReceptor {
 	float *locus;
 	unsigned int *receptors;
 	float nominal, threshold, gain;
-	void init(bioReceptorGene *, class c2eOrgan *, boost::shared_ptr<c2eReaction>);
+	void init(bioReceptorGene *, class c2eOrgan *, std::shared_ptr<c2eReaction>);
 };
 
 struct c2eEmitter {
@@ -57,7 +57,7 @@ protected:
 	class c2eCreature *parent;	
 	organGene *ourGene;
 
-	std::vector<boost::shared_ptr<c2eReaction> > reactions;
+	std::vector<std::shared_ptr<c2eReaction> > reactions;
 	std::vector<c2eReceptor> receptors;
 	std::vector<c2eEmitter> emitters;
 
@@ -120,7 +120,7 @@ protected:
 	std::vector<unsigned int> mappinginfo;
 	
 	// biochemistry
-	std::vector<boost::shared_ptr<c2eOrgan> > organs;
+	std::vector<std::shared_ptr<c2eOrgan> > organs;
 	float chemicals[256];
 
 	// loci
@@ -148,7 +148,7 @@ protected:
 	AgentRef selectRepresentativeAgent(int type, std::vector<AgentRef> possibles);
 
 public:
-	c2eCreature(boost::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a);
+	c2eCreature(std::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a);
 
 	void tick();
 
@@ -163,7 +163,7 @@ public:
 	void handleStimulus(unsigned int id, float strength);
 
 	unsigned int noOrgans() { return organs.size(); }
-	boost::shared_ptr<c2eOrgan> getOrgan(unsigned int i) { assert(i < organs.size()); return organs[i]; }
+	std::shared_ptr<c2eOrgan> getOrgan(unsigned int i) { assert(i < organs.size()); return organs[i]; }
 	
 	class c2eBrain *getBrain() { return brain; }
 

--- a/src/creatures/oldBrain.cpp
+++ b/src/creatures/oldBrain.cpp
@@ -849,7 +849,7 @@ unsigned int minimumLobeSize(unsigned int version, unsigned int lobeid) {
 void oldBrain::processGenes() {
 	// TODO: this likely doesn't work at all well in the presence of later-turn-on lobes
 
-	shared_ptr<genomeFile> genome = parent->getGenome();
+	std::shared_ptr<genomeFile> genome = parent->getGenome();
 	
 	for (vector<gene *>::iterator i = genome->genes.begin(); i != genome->genes.end(); i++) {
 		if (!parent->shouldProcessGene(*i)) continue;

--- a/src/creatures/oldBrain.h
+++ b/src/creatures/oldBrain.h
@@ -21,11 +21,11 @@
 #define __OLDBRAIN_H
 
 #include "genome.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <set>
 #include <map>
 
-using boost::shared_ptr;
+using std::shared_ptr;
 
 struct oldSVRule {
 	unsigned int length;

--- a/src/creatures/oldCreature.h
+++ b/src/creatures/oldCreature.h
@@ -47,7 +47,7 @@ protected:
 	void tickBrain();
 	virtual void tickBiochemistry();
 
-	oldCreature(boost::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a);
+	oldCreature(std::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a);
 
 	void processGenes();
 
@@ -95,7 +95,7 @@ struct c1Emitter {
 
 class c1Creature : public oldCreature {
 protected:
-	std::vector<boost::shared_ptr<c1Reaction> > reactions;
+	std::vector<std::shared_ptr<c1Reaction> > reactions;
 	std::vector<c1Receptor> receptors;
 	std::vector<c1Emitter> emitters;
 	
@@ -111,7 +111,7 @@ protected:
 	void processReceptor(c1Receptor &);
 	
 public:
-	c1Creature(boost::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a);
+	c1Creature(std::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a);
 
 	void tick();
 
@@ -152,7 +152,7 @@ protected:
 	class c2Creature *parent;
 	organGene *ourGene;
 
-	std::vector<boost::shared_ptr<c2Reaction> > reactions;
+	std::vector<std::shared_ptr<c2Reaction> > reactions;
 	std::vector<c2Receptor> receptors;
 	std::vector<c2Emitter> emitters;
 
@@ -201,7 +201,7 @@ public:
 class c2Creature : public oldCreature {
 protected:
 	// biochemistry
-	std::vector<boost::shared_ptr<c2Organ> > organs;
+	std::vector<std::shared_ptr<c2Organ> > organs;
 
 	// loci
 	unsigned char senses[14];
@@ -214,7 +214,7 @@ protected:
 	void processGenes();
 
 public:
-	c2Creature(boost::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a);
+	c2Creature(std::shared_ptr<genomeFile> g, bool is_female, unsigned char _variant, CreatureAgent *a);
 
 	void tick();
 	

--- a/src/creaturesImage.cpp
+++ b/src/creaturesImage.cpp
@@ -28,7 +28,7 @@ bool creaturesImage::transparentAt(unsigned int frame, unsigned int x, unsigned 
 	return false;
 }
 
-boost::shared_ptr<creaturesImage> creaturesImage::mutableCopy() {
+std::shared_ptr<creaturesImage> creaturesImage::mutableCopy() {
 	throw creaturesException("Internal error: Tried to make a mutable copy of a sprite which doesn't support that.");
 }
 

--- a/src/creaturesImage.h
+++ b/src/creaturesImage.h
@@ -23,7 +23,7 @@
 #include <string>
 #include <fstream>
 #include <cassert>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "endianlove.h"
 
@@ -59,7 +59,7 @@ public:
 	virtual uint8 *getCustomPalette();
 	
 	virtual bool transparentAt(unsigned int frame, unsigned int x, unsigned int y);
-	virtual boost::shared_ptr<creaturesImage> mutableCopy();
+	virtual std::shared_ptr<creaturesImage> mutableCopy();
 	virtual void tint(unsigned char r, unsigned char g, unsigned char b, unsigned char rotation, unsigned char swap);
 };
 

--- a/src/dialect.cpp
+++ b/src/dialect.cpp
@@ -35,7 +35,7 @@ int Dialect::cmd_index(const cmdinfo *ci) const {
 	return (ci - cmds);
 }
 
-std::map<std::string, boost::shared_ptr<Dialect> > dialects;
+std::map<std::string, std::shared_ptr<Dialect> > dialects;
 
 void registerDelegates() {
 	registerAutoDelegates();

--- a/src/dialect.h
+++ b/src/dialect.h
@@ -4,7 +4,7 @@
 #include "cmddata.h"
 #include <string>
 #include <map>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class Dialect {
 	private:
@@ -26,7 +26,7 @@ class Dialect {
 		int cmd_index(const cmdinfo *) const;
 };
 
-extern std::map<std::string, boost::shared_ptr<Dialect> > dialects;
+extern std::map<std::string, std::shared_ptr<Dialect> > dialects;
 
 void registerDelegates();
 void freeDelegates();

--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -58,7 +58,7 @@ std::string parseFailure::prettyPrint() const {
 	return oss.str();
 }
 
-void caosException::trace(boost::shared_ptr<class script> scr, int traceindex) throw() {
+void caosException::trace(std::shared_ptr<class script> scr, int traceindex) throw() {
 	this->script = scr;
 	this->traceindex = traceindex;
 }

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -27,7 +27,7 @@
 #include <vector>
 #include <sstream>
 #include <assert.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/scoped_ptr.hpp>
 #include <iostream> // for stupid copy constructor debug below
 
@@ -63,7 +63,7 @@ public:
 
 class caosException : public creaturesException {
 	protected:
-		boost::shared_ptr<class script> script;
+		std::shared_ptr<class script> script;
 		int traceindex;
 
 	public:
@@ -76,7 +76,7 @@ class caosException : public creaturesException {
 
 		caosException(const char *d) throw() : creaturesException(d), traceindex(-1) { }
 
-		void trace(boost::shared_ptr<class script> scr, int traceindex = -1) throw();
+		void trace(std::shared_ptr<class script> scr, int traceindex = -1) throw();
 
 		virtual std::string prettyPrint() const;
 };
@@ -110,7 +110,7 @@ public:
 		: creaturesException(s), lineno(-1) { }
 	~parseFailure() throw() { }
 
-	boost::shared_ptr<std::vector<class token> > context;
+	std::shared_ptr<std::vector<class token> > context;
 	int ctxoffset;
 	std::string filename;
 	int lineno;

--- a/src/fileSwapper.cpp
+++ b/src/fileSwapper.cpp
@@ -54,7 +54,7 @@ void fileSwapper::convertc16(std::string src, std::string dest) {
 	// okay. read the damn file.
 	c16Image img(in, src);
 
-	shared_ptr<creaturesImage> imgcopy = img.mutableCopy();
+	std::shared_ptr<creaturesImage> imgcopy = img.mutableCopy();
 	s16Image *i = dynamic_cast<s16Image *>(imgcopy.get());
 	assert(i);
 	

--- a/src/historyManager.cpp
+++ b/src/historyManager.cpp
@@ -44,7 +44,7 @@ historyevent::historyevent(unsigned int eno, CreatureAgent *c) {
 	}
 }
 
-void monikerData::init(std::string m, shared_ptr<genomeFile> f) {
+void monikerData::init(std::string m, std::shared_ptr<genomeFile> f) {
 	moniker = m;
 	status = unreferenced;
 	warpveteran = false;
@@ -74,7 +74,7 @@ historyevent &monikerData::addEvent(unsigned int event, std::string moniker1, st
 	events.back().monikers[0] = moniker1;
 	events.back().monikers[1] = moniker2;
 
-	for (std::list<boost::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
+	for (std::list<std::shared_ptr<Agent> >::iterator i = world.agents.begin(); i != world.agents.end(); i++) {
 		if (!*i) continue;
 
 		(*i)->queueScript(127, 0, moniker, (int)(events.size() - 1)); // new life event
@@ -147,7 +147,7 @@ monikerstatus monikerData::getStatus() {
 
 }
 
-std::string historyManager::newMoniker(shared_ptr<genomeFile> genome) {
+std::string historyManager::newMoniker(std::shared_ptr<genomeFile> genome) {
 	unsigned int genus = 0;
 	
 	for (vector<gene *>::iterator i = genome->genes.begin(); i != genome->genes.end(); i++) {
@@ -208,7 +208,7 @@ monikerData &historyManager::getMoniker(std::string s) {
 	return i->second;
 }
 
-std::string historyManager::findMoniker(shared_ptr<genomeFile> g) {
+std::string historyManager::findMoniker(std::shared_ptr<genomeFile> g) {
 	for (std::map<std::string, monikerData>::iterator i = monikers.begin(); i != monikers.end(); i++) {
 		if (i->second.genome.lock() == g) return i->first;
 	}

--- a/src/historyManager.h
+++ b/src/historyManager.h
@@ -24,10 +24,10 @@
 #include "creatures/lifestage.h"
 #include <vector>
 #include <map>
-#include <boost/weak_ptr.hpp>
+#include <memory>
 
-using boost::shared_ptr;
-using boost::weak_ptr;
+using std::shared_ptr;
+using std::weak_ptr;
 
 class genomeFile;
 
@@ -64,7 +64,7 @@ public:
 	bool warpveteran;
 	unsigned int no_crossover_points, no_point_mutations;
 	
-	void init(std::string, shared_ptr<genomeFile>);
+	void init(std::string, std::shared_ptr<genomeFile>);
 	historyevent &addEvent(unsigned int event, std::string moniker1 = "", std::string moniker2 = "");
 	void moveToAgent(AgentRef a);
 	void moveToCreature(AgentRef c);
@@ -78,10 +78,10 @@ private:
 	std::map<std::string, monikerData> monikers;
 
 public:
-	std::string newMoniker(shared_ptr<genomeFile>);
+	std::string newMoniker(std::shared_ptr<genomeFile>);
 	bool hasMoniker(std::string);
 	monikerData &getMoniker(std::string);
-	std::string findMoniker(shared_ptr<genomeFile>);
+	std::string findMoniker(std::shared_ptr<genomeFile>);
 	std::string findMoniker(AgentRef);
 	void delMoniker(std::string);
 };

--- a/src/imageManager.cpp
+++ b/src/imageManager.cpp
@@ -40,7 +40,7 @@ using namespace boost::filesystem;
 
 enum filetype { blk, s16, c16, spr, bmp };
 
-bool tryOpen(mmapifstream *in, shared_ptr<creaturesImage> &img, std::string fname, filetype ft) {
+bool tryOpen(mmapifstream *in, std::shared_ptr<creaturesImage> &img, std::string fname, filetype ft) {
 	path cachefile, realfile;
 	std::string cachename;
 	if (fname.size() < 5) return false; // not enough chars for an extension and filename..
@@ -108,11 +108,11 @@ bool tryOpen(mmapifstream *in, shared_ptr<creaturesImage> &img, std::string fnam
 done:
 	if (in->is_open()) {
 		switch (ft) {
-			case blk: img = shared_ptr<creaturesImage>(new blkImage(in, basename)); break;
-			case c16: img = shared_ptr<creaturesImage>(new c16Image(in, basename)); break; // this should never happen, actually, once we're done
-			case s16: img = shared_ptr<creaturesImage>(new s16Image(in, basename)); break;
-			case spr: img = shared_ptr<creaturesImage>(new sprImage(in, basename)); break;
-			case bmp: img = shared_ptr<creaturesImage>(new bmpImage(in, basename)); break; // TODO: don't commit this ;p
+			case blk: img = std::shared_ptr<creaturesImage>(new blkImage(in, basename)); break;
+			case c16: img = std::shared_ptr<creaturesImage>(new c16Image(in, basename)); break; // this should never happen, actually, once we're done
+			case s16: img = std::shared_ptr<creaturesImage>(new s16Image(in, basename)); break;
+			case spr: img = std::shared_ptr<creaturesImage>(new sprImage(in, basename)); break;
+			case bmp: img = std::shared_ptr<creaturesImage>(new bmpImage(in, basename)); break; // TODO: don't commit this ;p
 		}
 	}
 	return in->is_open();
@@ -122,18 +122,18 @@ done:
  * Retrieve an image for rendering use. To retrieve a sprite, pass the name without
  * extension. To retrieve a background, pass the full filename (ie, with .blk).
  */
-shared_ptr<creaturesImage> imageManager::getImage(std::string name, bool is_background) {
-	if (name.empty()) return shared_ptr<creaturesImage>(); // empty sprites definitely don't exist
+std::shared_ptr<creaturesImage> imageManager::getImage(std::string name, bool is_background) {
+	if (name.empty()) return std::shared_ptr<creaturesImage>(); // empty sprites definitely don't exist
 
 	// step one: see if the image is already in the gallery
-	std::map<std::string, boost::weak_ptr<creaturesImage> >::iterator i = images.find(name);
+	std::map<std::string, std::weak_ptr<creaturesImage> >::iterator i = images.find(name);
 	if (i != images.end() && i->second.lock()) {
 		if (!is_background) return i->second.lock(); // TODO: handle backgrounds
 	}
 
 	// step two: try opening it in .c16 form first, then try .s16 form
 	mmapifstream *in = new mmapifstream();
-	shared_ptr<creaturesImage> img;
+	std::shared_ptr<creaturesImage> img;
 
 	std::string fname;
 	if (is_background) {
@@ -166,7 +166,7 @@ shared_ptr<creaturesImage> imageManager::getImage(std::string name, bool is_back
 	} else {
 		std::cerr << "imageGallery couldn't find the sprite '" << name << "'" << std::endl;
 		delete in;
-		return shared_ptr<creaturesImage>();
+		return std::shared_ptr<creaturesImage>();
 	}
 
 	in->close(); // doesn't close the mmap, which we still need :)

--- a/src/imageManager.h
+++ b/src/imageManager.h
@@ -21,17 +21,15 @@
 #define _IMAGEMANAGER_H
 
 #include <map>
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
-
+#include <memory>
 class creaturesImage;
 
 class imageManager {
 protected:
-	std::map<std::string, boost::weak_ptr<creaturesImage> > images;
+	std::map<std::string, std::weak_ptr<creaturesImage> > images;
 
 public:
-	boost::shared_ptr<creaturesImage> getImage(std::string name, bool is_background = false);
+	std::shared_ptr<creaturesImage> getImage(std::string name, bool is_background = false);
 };
 
 #endif

--- a/src/images/bmpImage.cpp
+++ b/src/images/bmpImage.cpp
@@ -180,7 +180,7 @@ bmpData::~bmpData() {
 bmpImage::bmpImage(mmapifstream *in, std::string n) : creaturesImage(n) {
 	buffers = 0;
 
-	bmpdata = shared_ptr<bmpData>(new bmpData(in, n));
+	bmpdata = std::shared_ptr<bmpData>(new bmpData(in, n));
 	imgformat = bmpdata->imgformat;
 	setBlockSize(bmpdata->biWidth, bmpdata->biHeight);
 }

--- a/src/images/bmpImage.h
+++ b/src/images/bmpImage.h
@@ -46,7 +46,7 @@ public:
 
 class bmpImage : public creaturesImage {
 protected:
-	boost::shared_ptr<bmpData> bmpdata;
+	std::shared_ptr<bmpData> bmpdata;
 	void freeData();
 
 public:

--- a/src/images/c16Image.cpp
+++ b/src/images/c16Image.cpp
@@ -45,7 +45,7 @@ void c16Image::readHeader(std::istream &in) {
 	}
 }
 
-shared_ptr<creaturesImage> c16Image::mutableCopy() {
+std::shared_ptr<creaturesImage> c16Image::mutableCopy() {
 	s16Image *img = new s16Image();
 
 	img->imgformat = if_16bit;
@@ -62,10 +62,10 @@ shared_ptr<creaturesImage> c16Image::mutableCopy() {
 		memcpy(img->buffers[i], buffers[i], widths[i] * heights[i] * 2);
 	}
 
-	return shared_ptr<creaturesImage>(img);
+	return std::shared_ptr<creaturesImage>(img);
 }
 
-shared_ptr<creaturesImage> s16Image::mutableCopy() {
+std::shared_ptr<creaturesImage> s16Image::mutableCopy() {
 	s16Image *img = new s16Image();
 
 	img->imgformat = if_16bit;
@@ -82,7 +82,7 @@ shared_ptr<creaturesImage> s16Image::mutableCopy() {
 		memcpy(img->buffers[i], buffers[i], widths[i] * heights[i] * 2);
 	}
 	
-	return shared_ptr<creaturesImage>(img);
+	return std::shared_ptr<creaturesImage>(img);
 }
 
 c16Image::c16Image(mmapifstream *in, std::string n) : creaturesImage(n) {

--- a/src/images/c16Image.h
+++ b/src/images/c16Image.h
@@ -31,7 +31,7 @@ public:
 	c16Image(mmapifstream *, std::string n);
 	~c16Image();
 	void readHeader(std::istream &in);
-	boost::shared_ptr<creaturesImage> mutableCopy();
+	std::shared_ptr<creaturesImage> mutableCopy();
 	bool transparentAt(unsigned int frame, unsigned int x, unsigned int y);
 };
 
@@ -45,7 +45,7 @@ public:
 	~s16Image();
 	void readHeader(std::istream &in);
 	void writeHeader(std::ostream &out);
-	boost::shared_ptr<creaturesImage> mutableCopy();
+	std::shared_ptr<creaturesImage> mutableCopy();
 	void tint(unsigned char r, unsigned char g, unsigned char b, unsigned char rotation, unsigned char swap);
 	bool transparentAt(unsigned int frame, unsigned int x, unsigned int y);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,17 +51,17 @@ extern "C" int main(int argc, char *argv[]) {
 		std::cout << "openc2e (" << version << "), built " __DATE__ " " __TIME__ "\nCopyright (c) 2004-2008 "
 			"Alyssa Milburn and others\n\n";
 
-		engine.addPossibleBackend("sdl", shared_ptr<Backend>(new SDLBackend()));
+		engine.addPossibleBackend("sdl", std::shared_ptr<Backend>(new SDLBackend()));
 #ifdef QT_SUPPORT
-		boost::shared_ptr<QtBackend> qtbackend = boost::shared_ptr<QtBackend>(new QtBackend());
-		boost::shared_ptr<Backend> qtbackend_generic = boost::dynamic_pointer_cast<class Backend, class QtBackend>(qtbackend);
+		std::shared_ptr<QtBackend> qtbackend = std::shared_ptr<QtBackend>(new QtBackend());
+		std::shared_ptr<Backend> qtbackend_generic = std::dynamic_pointer_cast<class Backend, class QtBackend>(qtbackend);
 		engine.addPossibleBackend("qt", qtbackend_generic); // last-added backend is default
 #endif
 #ifdef SDLMIXER_SUPPORT
-		engine.addPossibleAudioBackend("sdlmixer", shared_ptr<AudioBackend>(new SDLMixerBackend()));
+		engine.addPossibleAudioBackend("sdlmixer", std::shared_ptr<AudioBackend>(new SDLMixerBackend()));
 #endif
 #ifdef OPENAL_SUPPORT
-		engine.addPossibleAudioBackend("openal", shared_ptr<AudioBackend>(new OpenALBackend()));
+		engine.addPossibleAudioBackend("openal", std::shared_ptr<AudioBackend>(new OpenALBackend()));
 #endif
 
 		// pass command-line flags to the engine, but do no other setup

--- a/src/openc2e.h
+++ b/src/openc2e.h
@@ -27,9 +27,8 @@
 #include <iostream>
 #include <cassert>
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/format.hpp>
-using boost::shared_ptr;
 
 #include "exceptions.h"
 

--- a/src/ser/s_caosScript.h
+++ b/src/ser/s_caosScript.h
@@ -35,14 +35,14 @@ SERIALIZE(script) {
 //	ar & obj.gsub; // XXX duplicate with labels
 }
 
-static std::map<const Dialect *, boost::shared_ptr<std::vector<std::string> > >
+static std::map<const Dialect *, std::shared_ptr<std::vector<std::string> > >
 	dialect_trans_map;
 
 static void make_trans_map(const Dialect *d) {
 	if (dialect_trans_map[d])
 		return;
 	std::vector<std::string> *p = new std::vector<std::string>(d->cmdcount());
-	dialect_trans_map[d] = boost::shared_ptr<std::vector<std::string> >(p);
+	dialect_trans_map[d] = std::shared_ptr<std::vector<std::string> >(p);
 	const struct cmdinfo *ci;
 	for (int i = 0; i < d->cmdcount(); i++) {
 		(*p)[i] = std::string(d->getcmd(i)->lookup_key);
@@ -57,7 +57,7 @@ POST_SAVE(script) {
 
 POST_LOAD(script) {
 	std::string name;
-	boost::shared_ptr<std::vector<std::string> > trans_map;
+	std::shared_ptr<std::vector<std::string> > trans_map;
 	ar & name;
 	ar & trans_map;
 

--- a/src/shared_str.h
+++ b/src/shared_str.h
@@ -15,7 +15,7 @@ class shared_str_b {
 class shared_str {
 	FRIEND_SERIALIZE(shared_str)
 	protected:
-		boost::shared_ptr<shared_str_b> p;
+		std::shared_ptr<shared_str_b> p;
 	public:
 		shared_str() : p(new shared_str_b()) { }
 		shared_str(const shared_str &v) : p(v.p) { }

--- a/src/tools/braininavat/braininavat.cpp
+++ b/src/tools/braininavat/braininavat.cpp
@@ -234,7 +234,7 @@ void BrainInAVat::loadFile(const QString &fileName) {
 
 	// read genome
 	f >> noskipws;
-	shared_ptr<genomeFile> gfile(new genomeFile());
+	std::shared_ptr<genomeFile> gfile(new genomeFile());
 	try {
 		f >> *gfile;
 	} catch (genomeException &e) {

--- a/src/tools/memstats.cpp
+++ b/src/tools/memstats.cpp
@@ -23,6 +23,6 @@ int main() {
     PSIZE(std::string);
     PSIZE(caosVar);
     PSIZE(caosVM);
-    PSIZE(boost::weak_ptr<Agent>);
+    PSIZE(std::weak_ptr<Agent>);
     return 0;
 }


### PR DESCRIPTION
## Summary
- include `<memory>` instead of Boost pointer headers
- use `std::shared_ptr` and `std::weak_ptr` throughout the codebase
- remove the Boost `shared_ptr` using directive from `openc2e.h`

## Testing
- `cmake ..` *(fails: Could NOT find SDL)*
- `perl runtests.pl tests` *(fails: openc2e not built)*

------
https://chatgpt.com/codex/tasks/task_e_6840d9835efc832ab7020e5cd8e9d753