### PR TITLE
Replace scoped_array with unique_ptr

### DIFF
--- a/src/backends/qtgui/c1cobfile.cpp
+++ b/src/backends/qtgui/c1cobfile.cpp
@@ -24,10 +24,9 @@ std::string readpascalstring(std::istream &s) {
 	else
 		size = a;
 
-	boost::scoped_array<char> x(new char[size]);
-	//char x[size];
-	s.read(x.get(), size);
-	return std::string(x.get(), size);
+       std::unique_ptr<char[]> x(new char[size]);
+       s.read(x.get(), size);
+       return std::string(x.get(), size);
 }
 
 c1cobfile::c1cobfile(std::ifstream &s) {

--- a/src/backends/qtgui/c1cobfile.h
+++ b/src/backends/qtgui/c1cobfile.h
@@ -21,7 +21,7 @@
 #include <string>
 #include "endianlove.h"
 #include "streamutils.h"
-#include <boost/scoped_array.hpp>
+#include <memory>
 #include <vector>
 
 std::string readpascalstring(std::istream &s);
@@ -38,7 +38,7 @@ struct c1cobfile {
 
 	uint32 imagewidth, imageheight;
 
-	boost::scoped_array<char> imagedata;
+       std::unique_ptr<char[]> imagedata;
 
 	c1cobfile(std::ifstream &s);
 };

--- a/src/tools/debugkit/debugkit.cpp
+++ b/src/tools/debugkit/debugkit.cpp
@@ -27,7 +27,7 @@
 
 #include <assert.h>
 #include <fstream>
-#include <boost/scoped_array.hpp>
+#include <memory>
 
 using namespace std;
 
@@ -186,10 +186,9 @@ std::string readpascalstring(std::istream &s) {
 	else
 		size = a;
 
-	boost::scoped_array<char> x(new char[size]);
-	//char x[size];
-	s.read(x.get(), size);
-	return std::string(x.get(), size);
+       std::unique_ptr<char[]> x(new char[size]);
+       s.read(x.get(), size);
+       return std::string(x.get(), size);
 }
 
 struct c1cobfile {
@@ -232,8 +231,8 @@ struct c1cobfile {
 		uint32 imageheight = read32(s);
 		uint16 secondimagewidth = read16(s);
 		assert(imagewidth == secondimagewidth);
-		boost::scoped_array<char> imagedata(new char[imagewidth * imageheight]);
-		s.read(imagedata.get(), imagewidth * imageheight);
+               std::unique_ptr<char[]> imagedata(new char[imagewidth * imageheight]);
+               s.read(imagedata.get(), imagewidth * imageheight);
 		name = readpascalstring(s);
 	}
 };


### PR DESCRIPTION
## Summary
- remove `boost::scoped_array` from DebugKit and Qt GUI COB loader
- replace with `std::unique_ptr<char[]>`
- include `<memory>` where needed

## Testing
- `cmake ..` *(fails: Could NOT find SDL)*

------
https://chatgpt.com/codex/tasks/task_e_6840d9811e68832aa1f01765a57f0168