### PR TITLE
Use std filesystem and regex

### DIFF
--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -31,12 +31,10 @@
 #include "peFile.h"
 #include "Camera.h"
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/convenience.hpp>
+#include <filesystem>
 #include <boost/program_options.hpp>
 #include <boost/format.hpp>
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 namespace po = boost::program_options;
 
 #ifndef _WIN32

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -22,7 +22,7 @@
 
 #include "caosVar.h"
 #include <map>
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 
 class Backend;
 class AudioBackend;
@@ -98,8 +98,8 @@ public:
 
 	bool noRun() { return cmdline_norun; }
 
-	boost::filesystem::path homeDirectory();
-	boost::filesystem::path storageDirectory();
+       std::filesystem::path homeDirectory();
+       std::filesystem::path storageDirectory();
 };
 
 extern Engine engine;

--- a/src/PathResolver.cpp
+++ b/src/PathResolver.cpp
@@ -19,9 +19,8 @@
 
 #include "PathResolver.h"
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/regex.hpp>
+#include <filesystem>
+#include <regex>
 #include <set>
 #include <map>
 #include <cctype>
@@ -33,7 +32,7 @@
 using std::map;
 using std::set;
 using std::string;
-using namespace boost::filesystem;
+using namespace std::filesystem;
 
 static set<string> dircache;
 static map<string, string> cache;
@@ -156,7 +155,7 @@ bool doCacheDir(path &dir) {
 	return true;
 }
 
-static boost::regex constructSearchPattern(const std::string &wild) {
+static std::regex constructSearchPattern(const std::string &wild) {
 	std::ostringstream matchbuf;
 	matchbuf << "^";
 	for (size_t i = 0; i < wild.size(); i++) {
@@ -171,7 +170,7 @@ static boost::regex constructSearchPattern(const std::string &wild) {
 	}
 	matchbuf << "$";
 	std::string matchstr = matchbuf.str();
-	return boost::regex(matchstr.c_str());
+       return std::regex(matchstr.c_str());
 }
 
 std::vector<std::string> findByWildcard(std::string dir, std::string wild) {
@@ -189,7 +188,7 @@ std::vector<std::string> findByWildcard(std::string dir, std::string wild) {
 	if (!doCacheDir(dirp))
 		return std::vector<std::string>();
 	std::vector<std::string> results;
-	boost::regex l = constructSearchPattern(wild);
+       std::regex l = constructSearchPattern(wild);
 
 	std::string lcdir = toLowerCase(dir);
 	std::map<string, string>::iterator skey = cache.lower_bound(dir);
@@ -203,8 +202,8 @@ std::vector<std::string> findByWildcard(std::string dir, std::string wild) {
 		if (skey->first.length() < lcdir.length() + 2)
 			continue;
 		filepart = toLowerCase(skey->first.substr(lcdir.length() + 1));
-		if (!boost::regex_match(filepart, l))
-			continue;
+               if (!std::regex_match(filepart, l))
+                       continue;
 		results.push_back(skey->second);
 	}
 	return results;

--- a/src/PathResolver.h
+++ b/src/PathResolver.h
@@ -22,7 +22,7 @@
 
 #include <string>
 #include <vector>
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 
 /* resolveFile
  *
@@ -30,7 +30,7 @@
  */
 bool resolveFile(std::string &srcPath);
 
-bool resolveFile(boost::filesystem::path &path);
+bool resolveFile(std::filesystem::path &path);
 
 std::vector<std::string> findByWildcard(std::string dir, std::string wild);
 

--- a/src/imageManager.cpp
+++ b/src/imageManager.cpp
@@ -32,11 +32,9 @@
 #include <iostream>
 #include <fstream>
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/convenience.hpp>
+#include <filesystem>
 
-using namespace boost::filesystem;
+using namespace std::filesystem;
 
 enum filetype { blk, s16, c16, spr, bmp };
 


### PR DESCRIPTION
## Summary
- replace Boost filesystem includes with `<filesystem>`
- switch namespace usages from Boost to `std`
- use `<regex>` and `std::regex`

## Testing
- `perl runtests.pl tests` *(fails: Can't exec "./openc2e" and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840d97fb4a8832aac8afc288214805c