### PR TITLE
Fix outdated comment in mmapifstream header

### DIFF
--- a/src/mmapifstream.h
+++ b/src/mmapifstream.h
@@ -23,16 +23,16 @@
 #include <string>
 #include <fstream>
 
-// todo: write destructor
+// Destructor properly closes any open file and mapping
 class mmapifstream : public std::ifstream {
 public:
-	bool live;
-	unsigned int filesize;
-	char *map;
-	mmapifstream() { live = false; }
-	mmapifstream(std::string filename);
-	~mmapifstream();
-	void mmapopen(std::string filename);
+        bool live;
+        unsigned int filesize;
+        char *map;
+        mmapifstream() { live = false; }
+        mmapifstream(std::string filename);
+        ~mmapifstream(); // cleans up resources
+        void mmapopen(std::string filename);
 };
 
 #endif


### PR DESCRIPTION
## Summary
- update mmapifstream header comment to reflect destructor implementation
- note that the destructor handles cleanup

## Testing
- `./runtests.pl` *(fails: "Can't exec ./openc2e")*

------
https://chatgpt.com/codex/tasks/task_e_6840d9770690832a8c1c28ec04afc7c9