### PR TITLE
Add fmt dependency and migrate selected formatting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ EXECUTE_PROCESS(COMMAND mkdir -p "${GEN}")
 
 SET(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS 1)
 SET(CMAKE_MODULE_PATH "${SRC}/cmake")
+include(FetchContent)
 
 SET(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "The type of build to perform. Valid values are: RelWithDebInfo (default), Debug, Release, MinSizeRel")
 IF (CMAKE_BUILD_TYPE STREQUAL "")
@@ -198,8 +199,17 @@ FIND_PACKAGE(ALUT)
 
 FIND_PACKAGE(Boost 1.34.0 COMPONENTS program_options filesystem thread regex serialization REQUIRED)
 FIND_LIBRARY(BOOST_SYSTEM_LIBRARY NAMES boost_system-mt)
+find_package(fmt QUIET)
+if(NOT fmt_FOUND)
+    FetchContent_Declare(
+        fmt
+        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+        GIT_TAG 10.2.1
+    )
+    FetchContent_MakeAvailable(fmt)
+endif()
 IF(OPENC2E_USE_QT)
-	find_package(Qt4 REQUIRED)
+        find_package(Qt4 REQUIRED)
 ENDIF(OPENC2E_USE_QT)
 
 SET(USE_OPENAL "NO")
@@ -270,9 +280,10 @@ TARGET_LINK_LIBRARIES(openc2e z m pthread
 	boost_program_options-mt
 	boost_serialization-mt
 	boost_filesystem-mt
-	boost_thread-mt
-	boost_regex-mt
-	)
+        boost_thread-mt
+        boost_regex-mt
+        fmt::fmt
+        )
 IF(BOOST_SYSTEM_LIBRARY)
 TARGET_LINK_LIBRARIES(openc2e boost_system-mt)
 ENDIF(BOOST_SYSTEM_LIBRARY)

--- a/src/SFCFile.cpp
+++ b/src/SFCFile.cpp
@@ -47,8 +47,8 @@
 #define TYPE_MACRO 14
 #define TYPE_OBJECT 100
 
-#include <boost/format.hpp>
-#define sfccheck(x) if (!(x)) throw creaturesException(std::string("failure while reading SFC file: '" #x "' in " __FILE__ " at line ") + boost::str(boost::format("%d") % __LINE__));
+#include <fmt/format.h>
+#define sfccheck(x) if (!(x)) throw creaturesException(fmt::format("failure while reading SFC file: '{}' in {} at line {}", #x, __FILE__, __LINE__));
 
 SFCFile::~SFCFile() {
 	// This contains all the objects we've constructed, so we can just zap this and
@@ -279,7 +279,7 @@ void SFCFile::setVersion(unsigned int v) {
 	} else if (v == 1) {
 		sfccheck(world.gametype == "c2");
 	} else {
-		throw creaturesException(boost::str(boost::format("unknown version# %d") % v));
+               throw creaturesException(fmt::format("unknown version# {}", v));
 	}
 
 	ver = v;
@@ -1216,13 +1216,12 @@ void SFCScenery::copyToWorld() {
 	p->is_transparent = true;
 }
 
-#include <boost/format.hpp>
 #include <sstream>
 
 #include "caosScript.h"
 
 void SFCScript::install() {
-	std::string scriptinfo = boost::str(boost::format("<SFC script %d, %d, %d: %d>") % (int)family % (int)genus % species % eventno);
+       std::string scriptinfo = fmt::format("<SFC script {}, {}, {}: {}>", (int)family, (int)genus, species, eventno);
 	caosScript script(world.gametype, scriptinfo);
 	std::istringstream s(data);
 	try {

--- a/src/openc2e.h
+++ b/src/openc2e.h
@@ -28,7 +28,7 @@
 #include <cassert>
 #include <vector>
 #include <boost/shared_ptr.hpp>
-#include <boost/format.hpp>
+#include <fmt/format.h>
 using boost::shared_ptr;
 
 #include "exceptions.h"
@@ -40,7 +40,7 @@ public:
 	assertFailure(const char *x) throw() : creaturesException(x) { }
 };
 
-#define caos_assert(x) if (!(x)) { throw caosException(boost::str(boost::format("%s thrown from %s:%d") % #x % __FILE__ % __LINE__)); }
+#define caos_assert(x) if (!(x)) { throw caosException(fmt::format("{} thrown from {}:{}", #x, __FILE__, __LINE__)); }
 #define ensure_assert(x) do {\
 	bool ensure__v = (x); \
 	if (!ensure__v) \


### PR DESCRIPTION
## Summary
- add fmt via FetchContent in CMake
- link fmt library
- use fmt for assertion messages
- use fmt in SFCFile error handling

## Testing
- `cmake -B build -S .` *(fails: Could NOT find SDL)*

------
https://chatgpt.com/codex/tasks/task_e_6840d975f294832aaafc72480f30197a