### PR TITLE
Fix typo in AgentHelpers comment

### DIFF
--- a/src/AgentHelpers.cpp
+++ b/src/AgentHelpers.cpp
@@ -40,7 +40,7 @@ bool agentIsVisible(Agent *seeing, Agent *a, float ownerx, float ownery, MetaRoo
 	double deltay = thisy - ownery; deltay *= deltay;
 	if ((deltax + deltay) > (seeing->range.getFloat() * seeing->range.getFloat())) return false;
 
-	// do the actual visibiltiy check using a line between centers
+       // do the actual visibility check using a line between centers
 	Point src(ownerx, ownery), dest(thisx, thisy);
 	Line dummywall; unsigned int dummydir;
 	shared_ptr<Room> newroom = ownerroom;


### PR DESCRIPTION
## Summary
- fix typo in `agentIsVisible` comment in `AgentHelpers.cpp`

## Testing
- `perl runtests.pl` *(fails: `./openc2e` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840d4b333ac832a9032eab839dbdf8f