### PR TITLE
Fix readstring buffer leak

### DIFF
--- a/src/cobFile.cpp
+++ b/src/cobFile.cpp
@@ -105,9 +105,11 @@ std::string readstring(std::istream &file) {
 	char *buf = (char *)malloc(n);
 
 	while (true) {
-		file.read(&buf[i], 1);
-		if (!file.good())
-			throw creaturesException("Failed to read string.");
+               file.read(&buf[i], 1);
+               if (!file.good()) {
+                       free(buf); // free buffer before throwing to avoid leaks
+                       throw creaturesException("Failed to read string.");
+               }
 
 		// found null terminator
 		if (buf[i] == 0) {


### PR DESCRIPTION
## Summary
- free temporary buffer when `readstring` fails

## Testing
- `cmake ..` (fails: Could NOT find SDL)

------
https://chatgpt.com/codex/tasks/task_e_6840d4b8c6bc832a80ff17382bf12f1c