### PR TITLE
Fix typos in tools CMakeLists

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Note: This will rebuild some .o files.
 # currently, cmake can't link object files directly.
-# It would be cleanest to seperate out a libmng, libpray, etc.
-# into seperate project subdirs, and then have tools depend on that.
+# It would be cleanest to separate out a libmng, libpray, etc.
+# into separate project subdirs, and then have tools depend on that.
 
 PROJECT (OPENC2E_TOOLS CXX)
 


### PR DESCRIPTION
## Summary
- correct spelling of `separate` in `src/tools/CMakeLists.txt`

## Testing
- `cmake ..` *(fails: Could NOT find SDL)*
- `perl runtests.pl` *(fails: Can't exec "./openc2e"*)

------
https://chatgpt.com/codex/tasks/task_e_6840d4bc73c0832aa776aeb270b96192