### PR TITLE
Fix multiple build issues

### DIFF
--- a/docs/openc2e.pod
+++ b/docs/openc2e.pod
@@ -119,4 +119,4 @@ modify it under the terms of the GNU Lesser General Public
 License as published by the Free Software Foundation; either
 version 2 of the License, or (at your option) any later version.
 
-=end
+=cut

--- a/parsedocs.pl
+++ b/parsedocs.pl
@@ -175,12 +175,15 @@ while (<>) {
 		print STDERR "Missing \%status for $fullname\n";
 	}
 
-	if (!$cat) {
-		$cat = lc $fnmap{$file} || 'unknown';
-	}
+        if (!$cat) {
+                my $val = $fnmap{$file};
+                $cat = defined $val ? lc $val : 'unknown';
+        }
 
-	$stackdelta = $pragma{stackdelta} if defined $pragma{stackdelta};
-	$stackdelta = "INT_MAX" if lc $pragma{stackdelta} eq "any";
+        if (defined $pragma{stackdelta}) {
+                $stackdelta = $pragma{stackdelta};
+                $stackdelta = "INT_MAX" if lc $pragma{stackdelta} eq "any";
+        }
 	die "Deprecated use of pragma retc for $fullname" if defined $pragma{retc};
 
 

--- a/src/Agent.h
+++ b/src/Agent.h
@@ -21,7 +21,6 @@
 #define __AGENT_H
 
 #include "AgentRef.h"
-#include <boost/enable_shared_from_this.hpp>
 #include <memory>
 #include "caosVar.h"
 #include "CompoundPart.h"
@@ -39,7 +38,7 @@ struct agentzorder {
 	bool operator()(const class Agent *s1, const class Agent *s2) const;
 };
 
-class Agent : public boost::enable_shared_from_this<Agent> {
+class Agent : public std::enable_shared_from_this<Agent> {
 	
 	friend struct agentzorder;
 	friend class caosVM;

--- a/src/AudioBackend.h
+++ b/src/AudioBackend.h
@@ -22,7 +22,6 @@
 
 #include <boost/intrusive_ptr.hpp>
 #include <memory>
-#include <boost/enable_shared_from_this.hpp>
 
 #include <string>
 
@@ -91,7 +90,7 @@ struct AudioStreamBase {
 
 enum SourceState { SS_STOP, SS_PLAY, SS_PAUSE };
 
-class AudioSource : public boost::enable_shared_from_this<AudioSource> {
+class AudioSource : public std::enable_shared_from_this<AudioSource> {
 protected:
 	AudioSource() { }
 
@@ -131,7 +130,7 @@ public:
 	virtual void setFollowingView(bool) = 0;
 };
 
-class AudioBackend : public boost::enable_shared_from_this<AudioBackend> {
+class AudioBackend : public std::enable_shared_from_this<AudioBackend> {
 protected:
 	AudioBackend() { }
 

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -31,10 +31,10 @@
 #include "peFile.h"
 #include "Camera.h"
 
-#include <filesystem>
+#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/format.hpp>
-namespace fs = std::filesystem;
+namespace fs = boost::filesystem;
 namespace po = boost::program_options;
 
 #ifndef _WIN32

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -22,7 +22,7 @@
 
 #include "caosVar.h"
 #include <map>
-#include <filesystem>
+#include <boost/filesystem.hpp>
 
 class Backend;
 class AudioBackend;
@@ -98,8 +98,8 @@ public:
 
 	bool noRun() { return cmdline_norun; }
 
-       std::filesystem::path homeDirectory();
-       std::filesystem::path storageDirectory();
+       boost::filesystem::path homeDirectory();
+       boost::filesystem::path storageDirectory();
 };
 
 extern Engine engine;

--- a/src/MusicManager.h
+++ b/src/MusicManager.h
@@ -24,7 +24,6 @@
 #include "endianlove.h"
 #include <memory>
 using std::shared_ptr;
-#include <boost/enable_shared_from_this.hpp>
 
 class MusicManager {
 private:
@@ -124,7 +123,7 @@ public:
 	MusicLayer *getParent() { return parent; }
 };
 
-class MusicLayer : public boost::enable_shared_from_this<class MusicLayer> {
+class MusicLayer : public std::enable_shared_from_this<class MusicLayer> {
 protected:
 	MNGUpdateNode *updatenode;
 
@@ -172,7 +171,7 @@ public:
 	void update(unsigned int latency);
 };
 
-class MusicTrack : public boost::enable_shared_from_this<class MusicTrack> {
+class MusicTrack : public std::enable_shared_from_this<class MusicTrack> {
 protected:
 	MNGTrackDecNode *node;
 	MNGFile *parent;

--- a/src/Room.h
+++ b/src/Room.h
@@ -40,7 +40,7 @@ struct RoomDoor {
 
 class Room {
 public:
-	std::map<std::weak_ptr<Room>,RoomDoor *> doors;
+       std::map<std::weak_ptr<Room>, RoomDoor *, std::owner_less<std::weak_ptr<Room>>> doors;
 	unsigned int x_left, x_right, y_left_ceiling, y_right_ceiling;
 	unsigned int y_left_floor, y_right_floor;
 	

--- a/src/dialect.h
+++ b/src/dialect.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <map>
 #include <memory>
+#include <cassert>
 
 class Dialect {
 	private:

--- a/writecmds.pl
+++ b/writecmds.pl
@@ -97,7 +97,7 @@ sub miscprep {
 sub printinit {
 	my ($variant, $cmdarr, $exparr) = @_;
 	print "static void init_$variant() {\n";
-	print qq{\tdialects["$variant"] = boost::shared_ptr<Dialect>(new Dialect($cmdarr, std::string("$variant")));\n};
+    print qq{\tdialects["$variant"] = std::shared_ptr<Dialect>(new Dialect($cmdarr, std::string("$variant")));\n};
 	print "}\n";
 	push @init_funcs, "init_$variant";
 }


### PR DESCRIPTION
## Summary
- fix doc termination marker
- fix parsedocs.pl uninitialized values
- prefer std::shared_ptr in generated dialect initialization
- use owner_less comparator for weak_ptr map in Room
- switch engine filesystem uses back to boost
- replace boost enable_shared_from_this with std equivalents
- include `<cassert>` in dialect.h

## Testing
- `cmake -DOPENC2E_USE_QT=OFF ..`
- `make -j4` *(fails: intrusive_ptr_release not declared)*

------
https://chatgpt.com/codex/tasks/task_e_6840e999e994832a8c9b826813ec55c5