### PR TITLE
Fix build issues

### DIFF
--- a/src/AudioBackend.h
+++ b/src/AudioBackend.h
@@ -20,21 +20,20 @@
 #ifndef SOUNDBACKEND_H
 #define SOUNDBACKEND_H 1
 
-#include <boost/intrusive_ptr.hpp>
 #include <memory>
 
 #include <string>
 
 class AudioBuffer;
 
-namespace boost {
-	static inline void intrusive_ptr_add_ref(AudioBuffer *p);
-	static inline void intrusive_ptr_release(AudioBuffer *p);
-}
+static inline void intrusive_ptr_add_ref(class AudioBuffer *p);
+static inline void intrusive_ptr_release(class AudioBuffer *p);
+
+#include <boost/intrusive_ptr.hpp>
 
 class AudioBuffer {
-	friend void boost::intrusive_ptr_add_ref(AudioBuffer *p);
-	friend void boost::intrusive_ptr_release(AudioBuffer *p);
+        friend void intrusive_ptr_add_ref(AudioBuffer *p);
+        friend void intrusive_ptr_release(AudioBuffer *p);
 
 protected:
 	virtual void add_ref() = 0;
@@ -47,13 +46,11 @@ public:
 };
 
 typedef boost::intrusive_ptr<AudioBuffer> AudioClip;
-namespace boost {
-	static inline void intrusive_ptr_add_ref(AudioBuffer *p) {
-		p->add_ref();
-	}
-	static inline void intrusive_ptr_release(AudioBuffer *p) {
-		p->del_ref();
-	}
+inline void intrusive_ptr_add_ref(AudioBuffer *p) {
+        p->add_ref();
+}
+inline void intrusive_ptr_release(AudioBuffer *p) {
+        p->del_ref();
 }
 
 /* Base class for sources of streaming data (eg, MNG music)

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -144,8 +144,8 @@ bool Map::collideLineWithRoomBoundaries(Point src, Point dest, std::shared_ptr<R
 	}*/
 
 	float distance = 100000000.0f; // TODO: lots.
-	bool foundsomething = false;
-	bool previousroom = (newroom);
+    bool foundsomething = false;
+    bool previousroom = static_cast<bool>(newroom);
 	Point oldpoint = where;
 	Line movement(src, dest);
 

--- a/src/Map.h
+++ b/src/Map.h
@@ -23,6 +23,7 @@
 #include "physics.h"
 #include "openc2e.h"
 #include <vector>
+#include <memory>
 
 class Room;
 class MetaRoom;

--- a/src/PathResolver.cpp
+++ b/src/PathResolver.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "PathResolver.h"
+#include <cassert>
 
 #include <filesystem>
 #include <regex>

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -585,7 +585,7 @@ void World::executeBootstrap(bool switcher) {
 			// iterate through each bootstrap directory
 			for (fs::directory_iterator d(b); d != fsend; ++d) {
 				if (fs::exists(*d) && fs::is_directory(*d)) {
-                                       std::string s = d->path().filename();
+                                        std::string s = d->path().filename().string();
 					// TODO: cvillage has switcher code in 'Startup', so i included it here too
 					if (s == "000 Switcher" || s == "Startup") {
 						if (!switcher) continue;

--- a/src/backends/qtgui/openc2eview.cpp
+++ b/src/backends/qtgui/openc2eview.cpp
@@ -20,6 +20,7 @@
 
 #include "openc2eview.h"
 #include <QtGui>
+#include <QScrollBar>
 #include "QtBackend.h"
 
 #ifdef _WIN32

--- a/src/backends/qtgui/qtopenc2e.cpp
+++ b/src/backends/qtgui/qtopenc2e.cpp
@@ -17,6 +17,9 @@
 #include "World.h"
 #include "qtopenc2e.h"
 #include <QtGui>
+#include <QAction>
+#include <QMessageBox>
+#include <QLabel>
 #include "openc2eview.h"
 #include "Engine.h"
 #include "AudioBackend.h"

--- a/src/backends/qtgui/qtopenc2e.h
+++ b/src/backends/qtgui/qtopenc2e.h
@@ -18,6 +18,7 @@
 #define _QTOPENC2E_H
 
 #include <QMainWindow>
+#include <QLabel>
 #include <memory>
 #include "AgentRef.h"
 

--- a/src/creatures/SkeletalCreature.cpp
+++ b/src/creatures/SkeletalCreature.cpp
@@ -37,6 +37,7 @@
 #include "creaturesImage.h"
 
 #include <typeinfo> // TODO: remove when genome system is fixed
+#include <memory>
 #include <boost/format.hpp>
 
 struct bodypartinfo {
@@ -431,8 +432,8 @@ void SkeletalCreature::snapDownFoot() {
 		footy = newfooty;
 	}
 
-	bool newroomchosen = (newroom != downfootroom) && downfootroom;
-	bool hadroom = (downfootroom);
+        bool newroomchosen = (newroom != downfootroom) && downfootroom;
+        bool hadroom = static_cast<bool>(downfootroom);
 	downfootroom = newroom;
 	
 	if (!downfootroom /*|| !falling */) {


### PR DESCRIPTION
## Summary
- fix intrusive_ptr declarations for AudioBuffer
- include missing headers for map and path utilities
- fix path resolution and world file path code
- address Qt build errors by including required Qt headers
- clean up boolean conversions for room variables

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: invalid use of incomplete type ‘class BrainViewer’)*

------
https://chatgpt.com/codex/tasks/task_e_6840ec960ee8832a91a69a21e57a3793